### PR TITLE
Feature/shading tweaks

### DIFF
--- a/Build/Configurations/Includes/PSXDoom_things.cfg
+++ b/Build/Configurations/Includes/PSXDoom_things.cfg
@@ -111,6 +111,7 @@ monsters
 		width = 16;
 		sprite = "SKULA8A2";
 		class = "LostSoul";
+		bright = 1;
 	}
 	
 	3005
@@ -391,6 +392,7 @@ health
 		title = "Green armor";
 		sprite = "ARM1A0";
 		class = "GreenArmor";
+		bright = 1;
 	}
 	
 	2019
@@ -398,6 +400,7 @@ health
 		title = "Blue armor";
 		sprite = "ARM2A0";
 		class = "BlueArmor";
+		bright = 1;
 	}
 }
 
@@ -418,6 +421,7 @@ powerups
 		sprite = "SOULA0";
 		height = 45;
 		class = "Soulsphere";
+		bright = 1;
 	}
 	
 	2022
@@ -426,6 +430,7 @@ powerups
 		sprite = "PINVA0";
 		height = 30;
 		class = "InvulnerabilitySphere";
+		bright = 1;
 	}
 	
 	2023
@@ -433,6 +438,7 @@ powerups
 		title = "Berserk";
 		sprite = "PSTRA0";
 		class = "Berserk";
+		bright = 1;
 	}
 	
 	2024
@@ -441,6 +447,7 @@ powerups
 		sprite = "PINSA0";
 		height = 45;
 		class = "BlurSphere";
+		bright = 1;
 	}
 	
 	2025
@@ -449,6 +456,7 @@ powerups
 		sprite = "SUITA0";
 		height = 60;
 		class = "RadSuit";
+		bright = 1;
 	}
 	
 	2026
@@ -457,6 +465,7 @@ powerups
 		sprite = "PMAPA0";
 		height = 35;
 		class = "Allmap";
+		bright = 1;
 	}
 	
 	2045
@@ -464,6 +473,7 @@ powerups
 		title = "Lite Amplification goggles";
 		sprite = "PVISA0";
 		class = "Infrared";
+		bright = 1;
 	}
 
 	83
@@ -472,6 +482,7 @@ powerups
 		sprite = "MEGAA0";
 		height = 40;
 		class = "Megasphere";
+		bright = 1;
 	}
 
 }
@@ -492,6 +503,7 @@ keys
 		title = "Blue keycard";
 		sprite = "BKEYA0";
 		class = "BlueCard";
+		bright = 1;
 	}
 	
 	40
@@ -499,6 +511,7 @@ keys
 		title = "Blue skullkey";
 		sprite = "BSKUB0";
 		class = "BlueSkull";
+		bright = 1;
 	}
 	
 	13
@@ -506,6 +519,7 @@ keys
 		title = "Red keycard";
 		sprite = "RKEYA0";
 		class = "RedCard";
+		bright = 1;
 	}
 	
 	38
@@ -513,6 +527,7 @@ keys
 		title = "Red skullkey";
 		sprite = "RSKUB0";
 		class = "RedSkull";
+		bright = 1;
 	}
 	
 	6
@@ -520,6 +535,7 @@ keys
 		title = "Yellow keycard";
 		sprite = "YKEYA0";
 		class = "YellowCard";
+		bright = 1;
 	}
 	
 	39
@@ -527,6 +543,7 @@ keys
 		title = "Yellow skullkey";
 		sprite = "YSKUB0";
 		class = "YellowSkull";
+		bright = 1;
 	}
 }
 
@@ -627,6 +644,7 @@ obstacles
 		title = "Evil Eye";
 		sprite = "CEYEA0";
 		class = "EvilEye";
+		bright = 1;
 	}
 	
 	42
@@ -634,6 +652,7 @@ obstacles
 		title = "Floating skull rock";
 		sprite = "FSKUA0";
 		class = "FloatingSkull";
+		bright = 1;
 	}
 
 	70
@@ -643,6 +662,7 @@ obstacles
 		sprite = "FCANA0";
 		height = 32;
 		class = "BurningBarrel";
+		bright = 1;
 	}
 
 }
@@ -664,6 +684,7 @@ lights
 		title = "Floor lamp";
 		sprite = "COLUA0";
 		class = "Column";
+		bright = 1;
 	}
 	
 	34
@@ -674,6 +695,7 @@ lights
 		blocking = 0;
 		error = 1;
 		class = "Candlestick";
+		bright = 1;
 	}
 	
 	35
@@ -681,6 +703,7 @@ lights
 		title = "Candelabra";
 		sprite = "CBRAA0";
 		class = "Candelabra";
+		bright = 1;
 	}
 	
 	44
@@ -688,6 +711,7 @@ lights
 		title = "Tall blue firestick";
 		sprite = "TBLUA0";
 		class = "BlueTorch";
+		bright = 1;
 	}
 	
 	45
@@ -695,6 +719,7 @@ lights
 		title = "Tall green firestick";
 		sprite = "TGRNA0";
 		class = "GreenTorch";
+		bright = 1;
 	}
 	
 	46
@@ -702,6 +727,7 @@ lights
 		title = "Tall red firestick";
 		sprite = "TREDA0";
 		class = "RedTorch";
+		bright = 1;
 	}
 	
 	55
@@ -709,6 +735,7 @@ lights
 		title = "Short blue firestick";
 		sprite = "SMBTA0";
 		class = "ShortBlueTorch";
+		bright = 1;
 	}
 	
 	56
@@ -716,6 +743,7 @@ lights
 		title = "Short green firestick";
 		sprite = "SMGTA0";
 		class = "ShortGreenTorch";
+		bright = 1;
 	}
 	
 	57
@@ -723,6 +751,7 @@ lights
 		title = "Short red firestick";
 		sprite = "SMRTA0";
 		class = "ShortRedTorch";
+		bright = 1;
 	}
 
 	85
@@ -730,6 +759,7 @@ lights
 		title = "Tall techno floor lamp";
 		sprite = "TLMPA0";
 		class = "TechLamp";
+		bright = 1;
 	}
 	
 	86
@@ -737,6 +767,7 @@ lights
 		title = "Short techno floor lamp";
 		sprite = "TLP2A0";
 		class = "TechLamp2";
+		bright = 1;
 	}
 
 	90//new id for gec
@@ -927,6 +958,7 @@ decoration
 		blocking = 1;
 		error = 2;
 		class = "HeadCandles";
+		bright = 1;
 	}
 	
 	10

--- a/Source/Core/Config/ThingTypeInfo.cs
+++ b/Source/Core/Config/ThingTypeInfo.cs
@@ -234,6 +234,9 @@ namespace CodeImp.DoomBuilder.Config
 			this.locksprite = cfg.ReadSetting("thingtypes." + cat.Name + "." + key + ".locksprite", false); //mxd
 			this.classname = cfg.ReadSetting("thingtypes." + cat.Name + "." + key + ".class", String.Empty); //mxd
 			this.thinglink = cfg.ReadSetting("thingtypes." + cat.Name + "." + key + ".thinglink", 0);
+			
+			// DC: allow 'bright' to be defined on the thing definition
+			this.bright = cfg.ReadSetting("thingtypes." + cat.Name + "." + key + ".bright", false);
 
 			//mxd. Read flagsrename
 			this.flagsrename = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);

--- a/Source/Core/Rendering/World3DShader.cs
+++ b/Source/Core/Rendering/World3DShader.cs
@@ -207,7 +207,7 @@ namespace CodeImp.DoomBuilder.Rendering
 		}
 
 
-        //[GEC] psxSetLightLevel
+        //[GEC] psxSetLightLevel	(Note: integer light level, not float!)
         private float LightLevel;
         public float SetLightLevel
         {

--- a/Source/Core/Resources/world3d.fx
+++ b/Source/Core/Resources/world3d.fx
@@ -286,7 +286,7 @@ float4 getFogColor(LitPixelData pd, float4 texColor, float4 sectorColor)
 	}
 	else
 	{
-		color = texColor * sectorColor;
+		color = texColor;
 	}
 
 	return float4(psxR5G5B5BitCrush(color.rgb), color.a);	// DC: bit crush to simulate the PlayStation's limitations

--- a/Source/Core/Resources/world3d.fx
+++ b/Source/Core/Resources/world3d.fx
@@ -38,7 +38,7 @@ struct LitPixelData
 	float4 pos		  : POSITION;
 	float4 color	  : COLOR0;
 	float2 uv		    : TEXCOORD0;
-	float3 pos_w    : TEXCOORD1; //mxd. pixel position in world space
+	float4 pos_w    : TEXCOORD1; //mxd. pixel position in world space (DC: added a 'w' component to encode pixel depth)
 	float3 normal   : TEXCOORD2; //mxd. normal
 };
 
@@ -137,7 +137,8 @@ LitPixelData vs_customvertexcolor_fog(VertexData vd)
 	
 	// Fill pixel data input
 	pd.pos = mul(float4(vd.pos, 1.0f), worldviewproj);
-	pd.pos_w = mul(float4(vd.pos, 1.0f), world).xyz;
+	pd.pos_w.xyz = mul(float4(vd.pos, 1.0f), world).xyz;
+	pd.pos_w.w = pd.pos.z;
 	pd.color = vertexColor;
 	pd.uv = vd.uv;
 	pd.normal = vd.normal;
@@ -151,7 +152,8 @@ LitPixelData vs_lightpass(VertexData vd)
 {
 	LitPixelData pd;
 	pd.pos = mul(float4(vd.pos, 1.0f), worldviewproj);
-	pd.pos_w = mul(float4(vd.pos, 1.0f), world).xyz;
+	pd.pos_w.xyz = mul(float4(vd.pos, 1.0f), world).xyz;
+	pd.pos_w.w = pd.pos.z;
 	pd.color = vd.color;
 	pd.uv = vd.uv;
 	pd.normal = vd.normal;
@@ -203,78 +205,91 @@ float4 ps_fullbright_highlight(PixelData pd) : COLOR
 	return float4(highlightcolor.rgb * highlightcolor.a + (tcolor.rgb - 0.4f * highlightcolor.a), max(pd.color.a + 0.25f, 0.5f));
 }
 
-//[GEC] Algoritmo por Erick Vasquez
-float4 PSXClut(float4 color)
+//----------------------------------------------------------------------------------------------------------------------
+// DC: calculations borrowed from PsyDoom to help accurately replicate PSX Doom in-game shading.
+// Quantizes/truncates the given color to R5G5B5 in a way that mimics how the PS1 truncates color.
+// Used to help reproduce the shading of the PlayStation.
+//----------------------------------------------------------------------------------------------------------------------
+float3 psxR5G5B5BitCrush(float3 color)
 {
-	float r = floor((color.r * 255.0) / 8.0);
-	float g = floor((color.g * 255.0) / 8.0) * 32.0;
-	float b = floor((color.b * 255.0) / 8.0) * 1024.0;
-
-	color.r = ((r * 8.0)) / 255.0;
-	color.g = ((g / 32.0) * 8.0) / 255.0;
-	color.b = ((b / 1024.0) * 8.0) / 255.0;
-
-	return color;
+	// Note: I added a slight amount here to prevent weird rounding/precision issues.
+	// This small bias prevents artifacts where pixels rapidly cycle between one 5-bit color component and the next.
+	return trunc(color * 31 + 0.0001) / 31;
 }
 
-//[GEC] Algoritmo por Erick Vasquez
-float R_DoomLightingEquationPSX(LitPixelData pd, float light)
+//----------------------------------------------------------------------------------------------------------------------
+// DC: calculations borrowed from PsyDoom to help accurately replicate PSX Doom in-game shading.
+// Compute the light diminishing multiplier for a pixel Z depth.
+//----------------------------------------------------------------------------------------------------------------------
+float getLightDiminishingMultiplier(float z)
 {
-	float Lightscale;
-	float Dist = distance(pd.pos_w, campos.xyz);
+	// Compute the basic light diminishing multiplier; a value of '128' means '1.0x' or no-change
+	float intensity;
 
 	if (LightMode == 1)
-		Dist = distance(pd.pos_w, campos.xy);
-
-	float Factor = (400.0 - Dist) / (1000.0);
-
-	if (LightMode == 1)
-		Factor = (400.0 - Dist) / (1000.0);
-	else if (LightMode == 2)
-		Factor = (250.0 - (Dist)) / (1040.0);
-	else if (LightMode == 3)
-		Factor = (400.0 - Dist) / (1000.0);
-
-	Factor = clamp(Factor, 0.0, (50.0 / 255.0)) * 255.0;
-
-	float L = (light * 255.0);
-	L = clamp(L - 8.0, 0.0, 255.0) / 2.0;
-
-	float Shade = clamp((L * (32.0 + Factor) + 32.0 / 2.0) / 32.0, L, 255.0);
-
-	Lightscale = clamp(Shade / 255.0, 0.0, 1.0);
-
-	return Lightscale;
-}
-
-//mxd. This adds fog color to current pixel color
-
-float4 getFogColor(LitPixelData pd, float4 color)
-{
-	float fogdist = max(16.0f, distance(pd.pos_w, campos.xyz));
-	float fogfactor = exp2(campos.w * fogdist);
-
-	color.rgb = lerp(lightColor.rgb, color.rgb, fogfactor);
-
-	if (LightMode != 0)
 	{
-		float newlightlevel = R_DoomLightingEquationPSX(pd, LightLevel);
-
-		color.rgb *= newlightlevel;
-		{
-			float level = 2.0;
-			if (LightMode == 3)
-				level = 1.2;
-
-			color.r = clamp(color.r * level, 0.0, 1.0);
-			color.g = clamp(color.g * level, 0.0, 1.0);
-			color.b = clamp(color.b * level, 0.0, 1.0);
-		}
-
-		color = PSXClut(color);
+		intensity = ((128.0 * 65536.0) / z) / 256.0;	// Walls
+	}
+	else if (LightMode == 2)
+	{
+		intensity = 160.0 - z * 0.5;	// Floors
+	}
+	else
+	{
+		intensity = 128.0;	// Things (no change)
 	}
 
-	return color;
+	// Clamp the intensity to the min/max allowed amounts (0.5x to 1.25x in normalized coords) and add a little
+	// bias to fix precision issues and flipping back and forth between values when the calculations are close:
+	intensity = trunc(clamp(intensity, 64.0, 160.0) + 0.0001);
+
+    // Scale the diminish intensity back to normalized color coords rather than 0-128
+    return intensity / 128.0;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// DC: calculations borrowed from PsyDoom to help accurately replicate PSX Doom in-game shading.
+// Compute the color for a pixel, given the texture color, sector color, light level (integer) and z-depth of the pixel.
+//----------------------------------------------------------------------------------------------------------------------
+float4 doPsxDoomShading(float4 texColor, float4 sectorColor, float lightLevel, float z){
+	// Convert input sector color to an integer value and modulate sector color by the light level (already an integer)
+	sectorColor.rgb = sectorColor.rgb * 255.0;
+	sectorColor.rgb = trunc((sectorColor.rgb * lightLevel) / 256.0);
+
+	// Compute color multiply after accounting for sector light color and light diminishing effects and then normalize.
+	// Add a little bias also to prevent switching back and forth between cases that are close, due to float inprecision.
+	float3 colorMul = trunc(sectorColor.rgb * getLightDiminishingMultiplier(z) + 0.0001) / 128.0;
+
+	// The PSX renderer doesn't allow the color multiply to go larger than this
+	colorMul = min(colorMul, 255.0 / 128.0);
+
+	// Make sure the input texture only uses 5-bit color to simulate the PlayStation's limitations.
+	// It might be the case that the user is using 8-bit color (preview) textures to edit the level, which will later be converted to 5-bit.
+	// This code assumes the user's tools would do some sort of rounding to 5-bit for the PSX assets, which is probably a reasonable assumption.
+	texColor.rgb *= 31;
+	texColor.rgb = round(texColor.rgb);
+	texColor.rgb /= 31;
+
+	// Apply the color multiply and return the shaded pixel
+	return float4(texColor.rgb * colorMul, texColor.a);
+}
+
+// mxd. This adds fog color to current pixel color.
+// DC: removed fog to simplify the shading since it is not something that is used in-game.
+float4 getFogColor(LitPixelData pd, float4 texColor, float4 sectorColor)
+{
+	float4 color;
+	
+	if (LightMode != 0)
+	{
+		color = doPsxDoomShading(texColor, sectorColor, LightLevel, pd.pos_w.w);
+	}
+	else
+	{
+		color = texColor * sectorColor;
+	}
+
+	return float4(psxR5G5B5BitCrush(color.rgb), color.a);	// DC: bit crush to simulate the PlayStation's limitations
 }
 
 //mxd. Shaders with fog calculation
@@ -285,7 +300,7 @@ float4 ps_main_fog(LitPixelData pd) : COLOR
 	tcolor = lerp(tcolor, float4(stencilColor.rgb, tcolor.a), stencilColor.a);
 	if(tcolor.a == 0) return tcolor;
 	
-	return getFogColor(pd, tcolor * pd.color);
+	return getFogColor(pd, tcolor, pd.color);
 }
 
 // Normal pixel shader with highlight
@@ -296,7 +311,7 @@ float4 ps_main_highlight_fog(LitPixelData pd) : COLOR
 	if(tcolor.a == 0) return tcolor;
 	
 	// Blend texture color and vertex color
-	float4 ncolor = getFogColor(pd, tcolor * pd.color);
+	float4 ncolor = getFogColor(pd, tcolor, pd.color);
 	
 	return float4(highlightcolor.rgb * highlightcolor.a + (ncolor.rgb - 0.4f * highlightcolor.a), max(ncolor.a + 0.25f, 0.5f));
 }
@@ -319,13 +334,13 @@ float4 ps_lightpass(LitPixelData pd) : COLOR
 	//is face facing away from light source?
 	// [ZZ] oddly enough pd.normal is not a proper normal, so using dot on it returns rather unexpected results. wrapped in normalize().
 	//      update 01.02.2017: offset the equation by 3px back to try to emulate GZDoom's broken visibility check.
-	float diffuseContribution = dot(normalize(pd.normal), normalize(lightPosAndRadius.xyz - pd.pos_w + normalize(pd.normal)*3));
+	float diffuseContribution = dot(normalize(pd.normal), normalize(lightPosAndRadius.xyz - pd.pos_w.xyz + normalize(pd.normal)*3));
 	if (diffuseContribution < 0 && ignoreNormals < 0.5)
 		clip(-1);
 	diffuseContribution = max(diffuseContribution, 0); // to make sure
 
 	//is pixel in light range?
-	float dist = distance(pd.pos_w, lightPosAndRadius.xyz);
+	float dist = distance(pd.pos_w.xyz, lightPosAndRadius.xyz);
 	if(dist > lightPosAndRadius.w)
 		clip(-1);
 
@@ -342,7 +357,7 @@ float4 ps_lightpass(LitPixelData pd) : COLOR
     
     if (spotLight > 0.5)
     {
-        float3 lightDirection = normalize(lightPosAndRadius.xyz - pd.pos_w);
+        float3 lightDirection = normalize(lightPosAndRadius.xyz - pd.pos_w.xyz);
         float cosDir = dot(lightDirection, lightOrientation);
         float df = smoothstep(light2Radius.y, light2Radius.x, cosDir);
         lightColorMod.rgb *= df;

--- a/Source/Core/Resources/world3d.fx
+++ b/Source/Core/Resources/world3d.fx
@@ -264,8 +264,9 @@ float4 doPsxDoomShading(float4 texColor, float4 sectorColor, float lightLevel, f
 	colorMul = min(colorMul, 255.0 / 128.0);
 
 	// Make sure the input texture only uses 5-bit color to simulate the PlayStation's limitations.
-	// It might be the case that the user is using 8-bit color (preview) textures to edit the level, which will later be converted to 5-bit.
-	// This code assumes the user's tools would do some sort of rounding to 5-bit for the PSX assets, which is probably a reasonable assumption.
+	// It might be the case that the user is using 8-bit color (preview) textures to edit the level, which will later be
+	// converted to the PlayStation's palette, which has 5-bit source color components. This truncation is an estimation
+	// of how all these conversions might look...
 	texColor.rgb *= 31;
 	texColor.rgb = round(texColor.rgb);
 	texColor.rgb /= 31;

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualThing.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualThing.cs
@@ -305,7 +305,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 
                         if (General.Map.PSXDOOM)//[GEC]
                         {
-                            base.lightlevel = (float)(brightness / 255.0f);
+                            base.lightlevel = brightness;
                             areabrightness = PixelColor.FromInt(mode.CalculateBrightness(255));
                             areacolor = PixelColor.Modulate(level.colorbelow, areabrightness);
                         }

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualThing.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualThing.cs
@@ -305,7 +305,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 
                         if (General.Map.PSXDOOM)//[GEC]
                         {
-                            base.lightlevel = brightness;
+                            base.lightlevel = sd.Sector.Brightness;
                             areabrightness = PixelColor.FromInt(mode.CalculateBrightness(255));
                             areacolor = PixelColor.Modulate(level.colorbelow, areabrightness);
                         }
@@ -337,6 +337,11 @@ namespace CodeImp.DoomBuilder.BuilderModes
 						//mxd. Calculate fogfactor
 						fogfactor = VisualGeometry.CalculateFogFactor(level.sector, level.brightnessbelow);
 					}
+
+                    if (General.Map.PSXDOOM)//[GEC]
+                    {
+                        base.lightlevel = 128;	// Fullbright: light level '128' means full brightness, anything over that is over-bright
+                    }
 				}
             }
 

--- a/Source/Plugins/BuilderModes/VisualModes/VisualCeiling.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualCeiling.cs
@@ -163,7 +163,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
             {
                 fogfactor = CalculateFogFactor(255);
                 base.lightmode = 2;
-                base.lightlevel = (float)(s.Brightness / 255.0f);
+                base.lightlevel = s.Brightness;
             }
 
             // Make vertices

--- a/Source/Plugins/BuilderModes/VisualModes/VisualFloor.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualFloor.cs
@@ -149,7 +149,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
             {
                 fogfactor = CalculateFogFactor(255);
                 base.lightmode = 2;
-                base.lightlevel = (float)(s.Brightness / 255.0f);
+                base.lightlevel = s.Brightness;
             }
 
             // Make vertices

--- a/Source/Plugins/BuilderModes/VisualModes/VisualLower.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualLower.cs
@@ -317,7 +317,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			int lightlevel = lightabsolute ? lightvalue : sd.Ceiling.brightnessbelow + lightvalue;
             if (General.Map.PSXDOOM)//[GEC]
             {
-                base.lightlevel = (float)(sd.Ceiling.sector.Brightness / 255.0f);
+                base.lightlevel = sd.Ceiling.sector.Brightness;
                 lightlevel = 255;
             }
 

--- a/Source/Plugins/BuilderModes/VisualModes/VisualMiddleDouble.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualMiddleDouble.cs
@@ -370,7 +370,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
             int lightlevel = lightabsolute ? lightvalue : sd.Ceiling.brightnessbelow + lightvalue;
             if (General.Map.PSXDOOM)//[GEC]
             {
-                base.lightlevel = (float)(sd.Ceiling.sector.Brightness / 255.0f);
+                base.lightlevel = sd.Ceiling.sector.Brightness;
                 lightlevel = 255;
             }
 

--- a/Source/Plugins/BuilderModes/VisualModes/VisualMiddleSingle.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualMiddleSingle.cs
@@ -260,7 +260,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 				int lightlevel = lightabsolute ? lightvalue : sd.Ceiling.brightnessbelow + lightvalue;
                 if (General.Map.PSXDOOM)//[GEC]
                 {
-                    base.lightlevel = (float)(sd.Ceiling.sector.Brightness / 255.0f);
+                    base.lightlevel = sd.Ceiling.sector.Brightness;
                     lightlevel = 256;
                 }
 

--- a/Source/Plugins/BuilderModes/VisualModes/VisualUpper.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualUpper.cs
@@ -297,7 +297,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			int lightlevel = lightabsolute ? lightvalue : sd.Ceiling.brightnessbelow + lightvalue;
             if (General.Map.PSXDOOM)//[GEC]
             {
-                base.lightlevel = (float)(sd.Ceiling.sector.Brightness / 255.0f);
+                base.lightlevel = sd.Ceiling.sector.Brightness;
                 lightlevel = 255;
             }
 


### PR DESCRIPTION
These are adjustments to make Doom Builder's shading match very closely the in-game shading result, with calculations borrowed directly from PsyDoom. I also fixed things not being affected by sector light levels and added a 'bright' setting for things that we want to view as fullbright in the editor such as lamps and torches. 

Here's what the currently released 'GZ Doom Builder Custom V3' looks like:
![image](https://user-images.githubusercontent.com/3496135/120882297-95d7b580-c58b-11eb-8595-b037f63464b5.png)

Here's what the Doom Builder looks like after the changes:
![image](https://user-images.githubusercontent.com/3496135/120882306-a5ef9500-c58b-11eb-9853-862f2254cf7e.png)

Here's the in-game shading (PsyDoom Vulkan renderer):
![image](https://user-images.githubusercontent.com/3496135/120882325-ba339200-c58b-11eb-89f4-193d998aa77e.png)

And here's the in-game shading in PsyDoom using the classic renderer:
![image](https://user-images.githubusercontent.com/3496135/120882332-cd466200-c58b-11eb-8c13-b5dc8c67c6ad.png)
