### PR TITLE
Feature/two color lighting

### DIFF
--- a/Build/Configurations/Psx_Doom.cfg
+++ b/Build/Configurations/Psx_Doom.cfg
@@ -17,7 +17,6 @@ enabledbydefault = true;
 //[GEC]
 showtexturestretched = true;
 ignorefloorskytexture = true;
-enablepsxdualcolorlighting = true;
 
 // *******************************************************
 // *                                                     *

--- a/Build/Configurations/Psx_Doom.cfg
+++ b/Build/Configurations/Psx_Doom.cfg
@@ -17,6 +17,7 @@ enabledbydefault = true;
 //[GEC]
 showtexturestretched = true;
 ignorefloorskytexture = true;
+enablepsxdualcolorlighting = true;
 
 // *******************************************************
 // *                                                     *

--- a/Build/Configurations/Psx_Doom_PsyDoom.cfg
+++ b/Build/Configurations/Psx_Doom_PsyDoom.cfg
@@ -18,6 +18,7 @@ game = "Doom: PsxDoom (PsyDoom extensions)";
 //[GEC]
 showtexturestretched = false;
 ignorefloorskytexture = false;
+enablepsxdualcolorlighting = true;
 
 linedefflags
 {

--- a/Build/Configurations/Psx_Doom_PsyDoom.cfg
+++ b/Build/Configurations/Psx_Doom_PsyDoom.cfg
@@ -60,6 +60,29 @@ sectorflags
     // 'invisible platform' effect...
     //----------------------------------------------------------------------------------------------
     2 = "Ghost Platform";
+
+    //----------------------------------------------------------------------------------------------
+    // These flags allow the sector height to be expanded or contracted for shading purposes.
+    // They offer a little control over the gradient with dual colored lighting.
+    //
+    // The adjustments are in multiples of the sector height (ceil - floor). Floors are normally
+    // adjusted downwards and ceilings upwards (expand mode), unless contract mode is being used.
+    //
+    // Adjustment amounts (expand):
+    //  +1  +0.5x sector shading height
+    //  +2  +1.0x sector shading height
+    //  +3  +2.0x sector shading height
+    //
+    // Adjustment amounts (contract):
+    //  +1  -0.25x sector shading height
+    //  +2  -0.5x  sector shading height
+    //  +3  -0.75x sector shading height
+    //----------------------------------------------------------------------------------------------
+    4 = "Gradient: Contract";
+    8 = "Gradient: Floor +1";
+    16 = "Gradient: Floor +2";
+    32 = "Gradient: Ceil +1";
+    64 = "Gradient: Ceil +2";
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/Source/Core/Config/GameConfiguration.cs
+++ b/Source/Core/Config/GameConfiguration.cs
@@ -92,6 +92,7 @@ namespace CodeImp.DoomBuilder.Config
 		private readonly bool localsidedeftextureoffsets; //MaxW
 		private readonly bool showtexturestretched; //[GEC]
 		private readonly bool ignorefloorskytexture; //[GEC]
+		private readonly bool enablepsxdualcolorlighting; //[GEC]
 
 		// Skills
 		private readonly List<SkillInfo> skills;
@@ -244,7 +245,7 @@ namespace CodeImp.DoomBuilder.Config
         public bool PSXDOOM { get { return psxdoommapformat; } }//[GEC]
 		public bool PSXDOOMTS { get { return showtexturestretched; } }//[GEC]
 		public bool PSXDOOM_IFST { get { return ignorefloorskytexture; } }//[GEC]
-		
+		public bool PSXDOOM_DCLIGHTS { get { return enablepsxdualcolorlighting; } }//[GEC]
 
 		public bool UseLocalSidedefTextureOffsets { get { return localsidedeftextureoffsets; } } //MaxW
 
@@ -421,7 +422,7 @@ namespace CodeImp.DoomBuilder.Config
             psxdoommapformat = (formatinterface == "PSXDoomMapSetIO");//[GEC]
 			showtexturestretched = cfg.ReadSetting("showtexturestretched", false);//[GEC]
 			ignorefloorskytexture = cfg.ReadSetting("ignorefloorskytexture", false);//[GEC]
-			
+			enablepsxdualcolorlighting = cfg.ReadSetting("enablepsxdualcolorlighting", false);//[GEC]
 
 			//mxd. Texture names length
 			longtexturenames = cfg.ReadSetting("longtexturenames", false);

--- a/Source/Core/Controls/SectorInfoPanel.Designer.cs
+++ b/Source/Core/Controls/SectorInfoPanel.Designer.cs
@@ -44,8 +44,10 @@ namespace CodeImp.DoomBuilder.Controls
             this.floorScaleLabel = new System.Windows.Forms.Label();
             this.sectorinfo = new System.Windows.Forms.GroupBox();
             this.ColorIndex = new System.Windows.Forms.Label();
+            this.ColorIndexCeil = new System.Windows.Forms.Label();
             this.panelIndexColor = new System.Windows.Forms.Panel();
             this.labelIndexColor = new System.Windows.Forms.Label();
+            this.labelIndexColorCeil = new System.Windows.Forms.Label();
             this.panelFadeColor = new System.Windows.Forms.Panel();
             this.panelLightColor = new System.Windows.Forms.Panel();
             this.labelFade = new System.Windows.Forms.Label();
@@ -75,6 +77,7 @@ namespace CodeImp.DoomBuilder.Controls
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.flagsPanel = new System.Windows.Forms.GroupBox();
             this.flags = new CodeImp.DoomBuilder.Controls.TransparentListView();
+            this.panelIndexColorCeil = new System.Windows.Forms.Panel();
             label13 = new System.Windows.Forms.Label();
             label5 = new System.Windows.Forms.Label();
             this.sectorinfo.SuspendLayout();
@@ -88,9 +91,9 @@ namespace CodeImp.DoomBuilder.Controls
             // 
             // label13
             // 
-            label13.Location = new System.Drawing.Point(183, 64);
+            label13.Location = new System.Drawing.Point(183, 42);
             label13.Name = "label13";
-            label13.Size = new System.Drawing.Size(70, 14);
+            label13.Size = new System.Drawing.Size(70, 13);
             label13.TabIndex = 14;
             label13.Text = "Brightness:";
             label13.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -215,8 +218,11 @@ namespace CodeImp.DoomBuilder.Controls
             // sectorinfo
             // 
             this.sectorinfo.Controls.Add(this.ColorIndex);
+            this.sectorinfo.Controls.Add(this.ColorIndexCeil);
             this.sectorinfo.Controls.Add(this.panelIndexColor);
+            this.sectorinfo.Controls.Add(this.panelIndexColorCeil);
             this.sectorinfo.Controls.Add(this.labelIndexColor);
+            this.sectorinfo.Controls.Add(this.labelIndexColorCeil);
             this.sectorinfo.Controls.Add(this.panelFadeColor);
             this.sectorinfo.Controls.Add(this.panelLightColor);
             this.sectorinfo.Controls.Add(this.labelFade);
@@ -245,18 +251,29 @@ namespace CodeImp.DoomBuilder.Controls
             // 
             this.ColorIndex.AutoSize = true;
             this.ColorIndex.Enabled = false;
-            this.ColorIndex.Location = new System.Drawing.Point(257, 78);
+            this.ColorIndex.Location = new System.Drawing.Point(257, 60);
             this.ColorIndex.Name = "ColorIndex";
             this.ColorIndex.Size = new System.Drawing.Size(13, 13);
             this.ColorIndex.TabIndex = 264;
             this.ColorIndex.Text = "0";
             this.ColorIndex.Visible = false;
             // 
+            // ColorIndexCeil
+            // 
+            this.ColorIndexCeil.AutoSize = true;
+            this.ColorIndexCeil.Enabled = false;
+            this.ColorIndexCeil.Location = new System.Drawing.Point(257, 79);
+            this.ColorIndexCeil.Name = "ColorIndexCeil";
+            this.ColorIndexCeil.Size = new System.Drawing.Size(13, 13);
+            this.ColorIndexCeil.TabIndex = 266;
+            this.ColorIndexCeil.Text = "0";
+            this.ColorIndexCeil.Visible = false;
+            // 
             // panelIndexColor
             // 
             this.panelIndexColor.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.panelIndexColor.Enabled = false;
-            this.panelIndexColor.Location = new System.Drawing.Point(282, 79);
+            this.panelIndexColor.Location = new System.Drawing.Point(282, 61);
             this.panelIndexColor.Name = "panelIndexColor";
             this.panelIndexColor.Size = new System.Drawing.Size(12, 12);
             this.panelIndexColor.TabIndex = 263;
@@ -265,18 +282,29 @@ namespace CodeImp.DoomBuilder.Controls
             // labelIndexColor
             // 
             this.labelIndexColor.Enabled = false;
-            this.labelIndexColor.Location = new System.Drawing.Point(183, 79);
+            this.labelIndexColor.Location = new System.Drawing.Point(183, 60);
             this.labelIndexColor.Name = "labelIndexColor";
-            this.labelIndexColor.Size = new System.Drawing.Size(70, 14);
+            this.labelIndexColor.Size = new System.Drawing.Size(70, 13);
             this.labelIndexColor.TabIndex = 262;
             this.labelIndexColor.Text = "Color Index:";
             this.labelIndexColor.TextAlign = System.Drawing.ContentAlignment.TopRight;
             this.labelIndexColor.Visible = false;
             // 
+            // labelIndexColorCeil
+            // 
+            this.labelIndexColorCeil.Enabled = false;
+            this.labelIndexColorCeil.Location = new System.Drawing.Point(164, 79);
+            this.labelIndexColorCeil.Name = "labelIndexColorCeil";
+            this.labelIndexColorCeil.Size = new System.Drawing.Size(89, 13);
+            this.labelIndexColorCeil.TabIndex = 265;
+            this.labelIndexColorCeil.Text = "Ceil color Index:";
+            this.labelIndexColorCeil.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            this.labelIndexColorCeil.Visible = false;
+            // 
             // panelFadeColor
             // 
             this.panelFadeColor.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.panelFadeColor.Location = new System.Drawing.Point(260, 50);
+            this.panelFadeColor.Location = new System.Drawing.Point(260, 26);
             this.panelFadeColor.Name = "panelFadeColor";
             this.panelFadeColor.Size = new System.Drawing.Size(20, 12);
             this.panelFadeColor.TabIndex = 21;
@@ -284,14 +312,14 @@ namespace CodeImp.DoomBuilder.Controls
             // panelLightColor
             // 
             this.panelLightColor.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.panelLightColor.Location = new System.Drawing.Point(260, 35);
+            this.panelLightColor.Location = new System.Drawing.Point(260, 11);
             this.panelLightColor.Name = "panelLightColor";
             this.panelLightColor.Size = new System.Drawing.Size(20, 12);
             this.panelLightColor.TabIndex = 20;
             // 
             // labelFade
             // 
-            this.labelFade.Location = new System.Drawing.Point(183, 49);
+            this.labelFade.Location = new System.Drawing.Point(183, 25);
             this.labelFade.Name = "labelFade";
             this.labelFade.Size = new System.Drawing.Size(70, 14);
             this.labelFade.TabIndex = 19;
@@ -300,7 +328,7 @@ namespace CodeImp.DoomBuilder.Controls
             // 
             // labelLight
             // 
-            this.labelLight.Location = new System.Drawing.Point(183, 34);
+            this.labelLight.Location = new System.Drawing.Point(183, 10);
             this.labelLight.Name = "labelLight";
             this.labelLight.Size = new System.Drawing.Size(70, 14);
             this.labelLight.TabIndex = 18;
@@ -309,9 +337,9 @@ namespace CodeImp.DoomBuilder.Controls
             // 
             // brightness
             // 
-            this.brightness.Location = new System.Drawing.Point(257, 64);
+            this.brightness.Location = new System.Drawing.Point(257, 42);
             this.brightness.Name = "brightness";
-            this.brightness.Size = new System.Drawing.Size(38, 14);
+            this.brightness.Size = new System.Drawing.Size(38, 13);
             this.brightness.TabIndex = 17;
             this.brightness.Text = "0";
             // 
@@ -575,6 +603,16 @@ namespace CodeImp.DoomBuilder.Controls
             this.flags.UseCompatibleStateImageBehavior = false;
             this.flags.View = System.Windows.Forms.View.List;
             // 
+            // panelIndexColorCeil
+            // 
+            this.panelIndexColorCeil.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.panelIndexColorCeil.Enabled = false;
+            this.panelIndexColorCeil.Location = new System.Drawing.Point(282, 79);
+            this.panelIndexColorCeil.Name = "panelIndexColorCeil";
+            this.panelIndexColorCeil.Size = new System.Drawing.Size(12, 12);
+            this.panelIndexColorCeil.TabIndex = 264;
+            this.panelIndexColorCeil.Visible = false;
+            // 
             // SectorInfoPanel
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -647,5 +685,8 @@ namespace CodeImp.DoomBuilder.Controls
         private System.Windows.Forms.Label ColorIndex;
         private System.Windows.Forms.Panel panelIndexColor;
         private System.Windows.Forms.Label labelIndexColor;
+        private System.Windows.Forms.Label labelIndexColorCeil;
+        private System.Windows.Forms.Label ColorIndexCeil;
+        private System.Windows.Forms.Panel panelIndexColorCeil;
     }
 }

--- a/Source/Core/Controls/SectorInfoPanel.Designer.cs
+++ b/Source/Core/Controls/SectorInfoPanel.Designer.cs
@@ -43,6 +43,9 @@ namespace CodeImp.DoomBuilder.Controls
             this.floorAngleLabel = new System.Windows.Forms.Label();
             this.floorScaleLabel = new System.Windows.Forms.Label();
             this.sectorinfo = new System.Windows.Forms.GroupBox();
+            this.ColorIndex = new System.Windows.Forms.Label();
+            this.panelIndexColor = new System.Windows.Forms.Panel();
+            this.labelIndexColor = new System.Windows.Forms.Label();
             this.panelFadeColor = new System.Windows.Forms.Panel();
             this.panelLightColor = new System.Windows.Forms.Panel();
             this.labelFade = new System.Windows.Forms.Label();
@@ -72,9 +75,6 @@ namespace CodeImp.DoomBuilder.Controls
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.flagsPanel = new System.Windows.Forms.GroupBox();
             this.flags = new CodeImp.DoomBuilder.Controls.TransparentListView();
-            this.ColorIndex = new System.Windows.Forms.Label();
-            this.panelIndexColor = new System.Windows.Forms.Panel();
-            this.labelIndexColor = new System.Windows.Forms.Label();
             label13 = new System.Windows.Forms.Label();
             label5 = new System.Windows.Forms.Label();
             this.sectorinfo.SuspendLayout();
@@ -240,6 +240,38 @@ namespace CodeImp.DoomBuilder.Controls
             this.sectorinfo.TabIndex = 2;
             this.sectorinfo.TabStop = false;
             this.sectorinfo.Text = " Sector ";
+            // 
+            // ColorIndex
+            // 
+            this.ColorIndex.AutoSize = true;
+            this.ColorIndex.Enabled = false;
+            this.ColorIndex.Location = new System.Drawing.Point(257, 78);
+            this.ColorIndex.Name = "ColorIndex";
+            this.ColorIndex.Size = new System.Drawing.Size(13, 13);
+            this.ColorIndex.TabIndex = 264;
+            this.ColorIndex.Text = "0";
+            this.ColorIndex.Visible = false;
+            // 
+            // panelIndexColor
+            // 
+            this.panelIndexColor.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.panelIndexColor.Enabled = false;
+            this.panelIndexColor.Location = new System.Drawing.Point(282, 79);
+            this.panelIndexColor.Name = "panelIndexColor";
+            this.panelIndexColor.Size = new System.Drawing.Size(12, 12);
+            this.panelIndexColor.TabIndex = 263;
+            this.panelIndexColor.Visible = false;
+            // 
+            // labelIndexColor
+            // 
+            this.labelIndexColor.Enabled = false;
+            this.labelIndexColor.Location = new System.Drawing.Point(183, 79);
+            this.labelIndexColor.Name = "labelIndexColor";
+            this.labelIndexColor.Size = new System.Drawing.Size(70, 14);
+            this.labelIndexColor.TabIndex = 262;
+            this.labelIndexColor.Text = "Color Index:";
+            this.labelIndexColor.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            this.labelIndexColor.Visible = false;
             // 
             // panelFadeColor
             // 
@@ -533,6 +565,7 @@ namespace CodeImp.DoomBuilder.Controls
             this.flags.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.flags.CheckBoxes = true;
             this.flags.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
+            this.flags.HideSelection = false;
             this.flags.Location = new System.Drawing.Point(6, 18);
             this.flags.Name = "flags";
             this.flags.Scrollable = false;
@@ -541,38 +574,6 @@ namespace CodeImp.DoomBuilder.Controls
             this.flags.TabIndex = 0;
             this.flags.UseCompatibleStateImageBehavior = false;
             this.flags.View = System.Windows.Forms.View.List;
-            // 
-            // ColorIndex
-            // 
-            this.ColorIndex.AutoSize = true;
-            this.ColorIndex.Enabled = false;
-            this.ColorIndex.Location = new System.Drawing.Point(257, 78);
-            this.ColorIndex.Name = "ColorIndex";
-            this.ColorIndex.Size = new System.Drawing.Size(13, 13);
-            this.ColorIndex.TabIndex = 264;
-            this.ColorIndex.Text = "0";
-            this.ColorIndex.Visible = false;
-            // 
-            // panelIndexColor
-            // 
-            this.panelIndexColor.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.panelIndexColor.Enabled = false;
-            this.panelIndexColor.Location = new System.Drawing.Point(282, 79);
-            this.panelIndexColor.Name = "panelIndexColor";
-            this.panelIndexColor.Size = new System.Drawing.Size(12, 12);
-            this.panelIndexColor.TabIndex = 263;
-            this.panelIndexColor.Visible = false;
-            // 
-            // labelIndexColor
-            // 
-            this.labelIndexColor.Enabled = false;
-            this.labelIndexColor.Location = new System.Drawing.Point(183, 79);
-            this.labelIndexColor.Name = "labelIndexColor";
-            this.labelIndexColor.Size = new System.Drawing.Size(70, 14);
-            this.labelIndexColor.TabIndex = 262;
-            this.labelIndexColor.Text = "Color Index:";
-            this.labelIndexColor.TextAlign = System.Drawing.ContentAlignment.TopRight;
-            this.labelIndexColor.Visible = false;
             // 
             // SectorInfoPanel
             // 

--- a/Source/Core/Controls/SectorInfoPanel.cs
+++ b/Source/Core/Controls/SectorInfoPanel.cs
@@ -361,14 +361,13 @@ namespace CodeImp.DoomBuilder.Controls
                     ColorIndex.Visible = true;  // [GEC]
                     ColorIndexCeil.Visible = true;  // [GEC]
 
-                    Lights Col = new Lights();
-                    PixelColor rgb = Col.GetLights(0);
-                    PixelColor rgbCeil = Col.GetLights(0);
+                    PixelColor rgb = Lights.GetColor(0);
+                    PixelColor rgbCeil = Lights.GetColor(0);
 
                     if (s.IdxColor != 0)
                     {
                         ColorIndex.Text = s.IdxColor.ToString();
-                        rgb = Col.GetLights(s.IdxColor);
+                        rgb = Lights.GetColor(s.IdxColor);
                         panelIndexColor.BackColor = Color.FromArgb(rgb.r, rgb.g, rgb.b);
                         labelIndexColor.Enabled = true;
                         panelIndexColor.Enabled = true;
@@ -386,7 +385,7 @@ namespace CodeImp.DoomBuilder.Controls
                     if (s.IdxColorCeil != 0)
                     {
                         ColorIndexCeil.Text = s.IdxColorCeil.ToString();
-                        rgbCeil = Col.GetLights(s.IdxColorCeil);
+                        rgbCeil = Lights.GetColor(s.IdxColorCeil);
                         panelIndexColorCeil.BackColor = Color.FromArgb(rgbCeil.r, rgbCeil.g, rgbCeil.b);
                         labelIndexColorCeil.Enabled = true;
                         panelIndexColorCeil.Enabled = true;

--- a/Source/Core/Controls/SectorInfoPanel.cs
+++ b/Source/Core/Controls/SectorInfoPanel.cs
@@ -353,13 +353,15 @@ namespace CodeImp.DoomBuilder.Controls
             {
                 if (s.Fields != null)
                 {
+                    bool useDualColoredLighting = General.Map.Config.PSXDOOM_DCLIGHTS;
+
                     //sector colors
                     labelIndexColor.Visible = true; // [GEC]
-                    labelIndexColorCeil.Visible = true; // [GEC]
+                    labelIndexColorCeil.Visible = useDualColoredLighting; // [GEC]
                     panelIndexColor.Visible = true; // [GEC]
-                    panelIndexColorCeil.Visible = true; // [GEC]
+                    panelIndexColorCeil.Visible = useDualColoredLighting; // [GEC]
                     ColorIndex.Visible = true;  // [GEC]
-                    ColorIndexCeil.Visible = true;  // [GEC]
+                    ColorIndexCeil.Visible = useDualColoredLighting;  // [GEC]
 
                     PixelColor rgb = Lights.GetColor(0);
                     PixelColor rgbCeil = Lights.GetColor(0);

--- a/Source/Core/Controls/SectorInfoPanel.cs
+++ b/Source/Core/Controls/SectorInfoPanel.cs
@@ -343,20 +343,27 @@ namespace CodeImp.DoomBuilder.Controls
 				foreach(Label label in ceillabels) label.Visible = showExtededCeilingInfo;
 
                 labelIndexColor.Visible = false;//[GEC]
+                labelIndexColorCeil.Visible = false;//[GEC]
                 panelIndexColor.Visible = false;//[GEC]
+                panelIndexColorCeil.Visible = false;//[GEC]
                 ColorIndex.Enabled = false;//[GEC]
+                ColorIndexCeil.Enabled = false;//[GEC]
             }
             else if (General.Map.PSXDOOM)//[GEC]
             {
                 if (s.Fields != null)
                 {
                     //sector colors
-                    labelIndexColor.Visible = true;
-                    panelIndexColor.Visible = true;
-                    ColorIndex.Visible = true;
+                    labelIndexColor.Visible = true; // [GEC]
+                    labelIndexColorCeil.Visible = true; // [GEC]
+                    panelIndexColor.Visible = true; // [GEC]
+                    panelIndexColorCeil.Visible = true; // [GEC]
+                    ColorIndex.Visible = true;  // [GEC]
+                    ColorIndexCeil.Visible = true;  // [GEC]
 
                     Lights Col = new Lights();
                     PixelColor rgb = Col.GetLights(0);
+                    PixelColor rgbCeil = Col.GetLights(0);
 
                     if (s.IdxColor != 0)
                     {
@@ -374,6 +381,24 @@ namespace CodeImp.DoomBuilder.Controls
                         panelIndexColor.Enabled = false;
                         ColorIndex.Enabled = false;
                         ColorIndex.Text = s.IdxColor.ToString();
+                    }
+
+                    if (s.IdxColorCeil != 0)
+                    {
+                        ColorIndexCeil.Text = s.IdxColorCeil.ToString();
+                        rgbCeil = Col.GetLights(s.IdxColorCeil);
+                        panelIndexColorCeil.BackColor = Color.FromArgb(rgbCeil.r, rgbCeil.g, rgbCeil.b);
+                        labelIndexColorCeil.Enabled = true;
+                        panelIndexColorCeil.Enabled = true;
+                        ColorIndexCeil.Enabled = true;
+                    }
+                    else
+                    {
+                        panelIndexColorCeil.BackColor = SystemColors.Control;
+                        labelIndexColorCeil.Enabled = false;
+                        panelIndexColorCeil.Enabled = false;
+                        ColorIndexCeil.Enabled = false;
+                        ColorIndexCeil.Text = s.IdxColorCeil.ToString();
                     }
 
                     //Flags

--- a/Source/Core/Geometry/Tools.cs
+++ b/Source/Core/Geometry/Tools.cs
@@ -606,6 +606,7 @@ namespace CodeImp.DoomBuilder.Geometry
 				newsector.CeilHeight = nearestsector.CeilHeight;
 				newsector.Brightness = nearestsector.Brightness;
                 newsector.IdxColor = nearestsector.IdxColor;//[GEC]
+				newsector.IdxColorCeil = nearestsector.IdxColorCeil;//[GEC]
             }
 			else
 			{
@@ -616,6 +617,7 @@ namespace CodeImp.DoomBuilder.Geometry
 				newsector.CeilHeight = General.Settings.DefaultCeilingHeight;
 				newsector.Brightness = General.Settings.DefaultBrightness;
                 newsector.IdxColor = 0;//[GEC]
+				newsector.IdxColorCeil = 0;//[GEC]
             }
 
 			//mxd. Apply overrides?

--- a/Source/Core/IO/ClipboardStreamReader.cs
+++ b/Source/Core/IO/ClipboardStreamReader.cs
@@ -140,6 +140,7 @@ namespace CodeImp.DoomBuilder.IO
 				int hceil = reader.ReadInt32();
 				int bright = reader.ReadInt32();
                 int idxcolor = reader.ReadInt32();//[GEC]
+				int idxcolorCeil = reader.ReadInt32();//[GEC]
 
                 //mxd. Tags
                 int numtags = reader.ReadInt32(); //mxd
@@ -182,7 +183,7 @@ namespace CodeImp.DoomBuilder.IO
 				Sector s = map.CreateSector();
 				if(s != null) 
 				{
-					s.Update(hfloor, hceil, tfloor, tceil, effect, stringflags, tags, bright, foffset, fslope, coffset, cslope, idxcolor);//[GEC]
+					s.Update(hfloor, hceil, tfloor, tceil, effect, stringflags, tags, bright, foffset, fslope, coffset, cslope, idxcolor, idxcolorCeil);//[GEC]
 
 					// Add custom fields
 					s.Fields.BeforeFieldsChange();

--- a/Source/Core/IO/ClipboardStreamWriter.cs
+++ b/Source/Core/IO/ClipboardStreamWriter.cs
@@ -205,6 +205,7 @@ namespace CodeImp.DoomBuilder.IO
 				writer.Write(s.CeilHeight);
 				writer.Write(s.Brightness);
                 writer.Write(s.IdxColor);//[GEC]
+				writer.Write(s.IdxColorCeil);//[GEC]
 
                 //mxd. Tags
                 writer.Write(s.Tags.Count);

--- a/Source/Core/IO/PSXDoomMapSetIO.cs
+++ b/Source/Core/IO/PSXDoomMapSetIO.cs
@@ -222,10 +222,11 @@ namespace CodeImp.DoomBuilder.IO
                 string tfloor = Lump.MakeNormalName(reader.ReadBytes(8), WAD.ENCODING);
                 string tceil = Lump.MakeNormalName(reader.ReadBytes(8), WAD.ENCODING);
                 int bright = reader.ReadByte();
-                int idxcolor = reader.ReadByte();
+                int idxcolor = reader.ReadByte(); //[GEC]
                 int special = reader.ReadUInt16();
                 int tag = reader.ReadUInt16();
-                int flags = reader.ReadUInt16();
+                int flags = reader.ReadByte(); //[GEC]
+                int idxcolorCeil = reader.ReadByte(); //[GEC]
 
                 //mxd. Read flags
                 Dictionary<string, bool> stringflags = new Dictionary<string, bool>(StringComparer.Ordinal);
@@ -237,7 +238,7 @@ namespace CodeImp.DoomBuilder.IO
 
                 // Create new item
                 Sector s = map.CreateSector();
-                s.UpdatePsx(hfloor, hceil, tfloor, tceil, special, stringflags, tag, bright, idxcolor);
+                s.UpdatePsx(hfloor, hceil, tfloor, tceil, special, stringflags, tag, bright, idxcolor, idxcolorCeil);
 
                 // Add it to the lookup table
                 link.Add(i, s);
@@ -580,7 +581,8 @@ namespace CodeImp.DoomBuilder.IO
                     if (f.Value && int.TryParse(f.Key, out fnum)) flags |= fnum;
                 }
 
-                writer.Write((UInt16)flags);
+                writer.Write((Byte)flags);//[GEC]
+                writer.Write((Byte)s.IdxColorCeil);//[GEC]
             }
 
             // Find insert position and remove old lump

--- a/Source/Core/IO/UniversalStreamReader.cs
+++ b/Source/Core/IO/UniversalStreamReader.cs
@@ -426,7 +426,7 @@ namespace CodeImp.DoomBuilder.IO
 				Sector s = map.CreateSector();
 				if(s != null)
 				{
-					s.Update(hfloor, hceil, tfloor, tceil, special, stringflags, tags, bright, foffset, new Vector3D(fslopex, fslopey, fslopez).GetNormal(), coffset, new Vector3D(cslopex, cslopey, cslopez).GetNormal(), 0);//[GEC]
+					s.Update(hfloor, hceil, tfloor, tceil, special, stringflags, tags, bright, foffset, new Vector3D(fslopex, fslopey, fslopez).GetNormal(), coffset, new Vector3D(cslopex, cslopey, cslopez).GetNormal(), 0, 0);//[GEC]
 
 					// Custom fields
 					ReadCustomFields(c, s, "sector");

--- a/Source/Core/Map/Lights.cs
+++ b/Source/Core/Map/Lights.cs
@@ -120,11 +120,11 @@ namespace CodeImp.DoomBuilder.Map
             shadeParams.upperColorZ = sector.CeilHeight;
 
             // Set the lower and upper colors.
-            // Note: if the upper color is undefined, use the lower color as the upper color and early out.
+            // Note: if the upper color is undefined (or dual colored lighting disabled), use the lower color as the upper color and early out.
             shadeParams.lowerColor = PixelColor.Modulate(baseColor, GetColor(sector.IdxColor)).WithAlpha(255);
             int ceilColorIdx = sector.IdxColorCeil;
 
-            if (ceilColorIdx == 0)
+            if ((ceilColorIdx == 0) || (!General.Map.Config.PSXDOOM_DCLIGHTS))
             {
                 shadeParams.upperColor = shadeParams.lowerColor;
                 return;

--- a/Source/Core/Map/Lights.cs
+++ b/Source/Core/Map/Lights.cs
@@ -14,11 +14,22 @@
 #endregion
 
 using CodeImp.DoomBuilder.Rendering;
+using System;
 
 namespace CodeImp.DoomBuilder.Map
 {
     public static class Lights
     {
+        // [GEC] DC: the lower and upper colors for the wall polygon and the z values at which does colors are applied.
+        // These values are used to compute the color for a vertex depending on it's height with two colored lighting.
+        public struct ShadingParams
+        {
+            public PixelColor lowerColor;
+            public PixelColor upperColor;
+            public float lowerColorZ;
+            public float upperColorZ;
+        }
+
         static readonly byte[] LIGHTS_DATA = new byte[]
         {
             0xff, 0xff, 0xff, 0xD8, 0xDE, 0xE7, 0xC9, 0xD9, 0xE0, 0xBA, 0xD3, 0xDA,
@@ -98,6 +109,93 @@ namespace CodeImp.DoomBuilder.Map
                 LIGHTS_DATA[(lightIdx * 3) + 1],
                 LIGHTS_DATA[(lightIdx * 3) + 2]
             );
+        }
+
+        // [GEC] DC: A helper function that computes the shading parameters used for dual colored lighting given a sector and specified base color.
+        // Sets the lower and upper colors and the z values at which those colors apply (for interpolation purposes).
+        public static void ComputeShadingParams(Sector sector, PixelColor baseColor, out ShadingParams shadeParams)
+        {
+            // Basic floor/ceiling z values for shading
+            shadeParams.lowerColorZ = sector.FloorHeight;
+            shadeParams.upperColorZ = sector.CeilHeight;
+
+            // Set the lower and upper colors.
+            // Note: if the upper color is undefined, use the lower color as the upper color and early out.
+            shadeParams.lowerColor = PixelColor.Modulate(baseColor, GetColor(sector.IdxColor)).WithAlpha(255);
+            int ceilColorIdx = sector.IdxColorCeil;
+
+            if (ceilColorIdx == 0)
+            {
+                shadeParams.upperColor = shadeParams.lowerColor;
+                return;
+            }
+
+            shadeParams.upperColor = PixelColor.Modulate(baseColor, GetColor(ceilColorIdx)).WithAlpha(255);
+
+            // Get the flags encoding how to adjust the gradient.
+            // This is not the most efficient (or elegant) way of looking up these flags but probably fine for the purposes of an editor.
+            bool bContractGradient = sector.IsFlagSet("4");
+            bool bFloorGradPlus1 = sector.IsFlagSet("8");
+            bool bFloorGradPlus2 = sector.IsFlagSet("16");
+            bool bCeilGradPlus1 = sector.IsFlagSet("32");
+            bool bCeilGradPlus2 = sector.IsFlagSet("64");
+
+            // Adjust the floor/ceiling z values for the purposes of shading (if adjustments are specified)
+            float sectorHeight = Math.Max(shadeParams.upperColorZ - shadeParams.lowerColorZ, 0);
+            int floorGradShift = (bFloorGradPlus1 ? 1 : 0) + (bFloorGradPlus2 ? 2 : 0);
+            int ceilGradShift = (bCeilGradPlus1 ? 1 : 0) + (bCeilGradPlus2 ? 2 : 0);
+
+            if (bContractGradient)
+            {
+                switch (floorGradShift)
+                {
+                    case 1: shadeParams.lowerColorZ += sectorHeight * 0.25f; break;
+                    case 2: shadeParams.lowerColorZ += sectorHeight * 0.50f; break;
+                    case 3: shadeParams.lowerColorZ += sectorHeight * 0.75f; break;
+                }
+
+                switch (ceilGradShift)
+                {
+                    case 1: shadeParams.upperColorZ -= sectorHeight * 0.25f; break;
+                    case 2: shadeParams.upperColorZ -= sectorHeight * 0.50f; break;
+                    case 3: shadeParams.upperColorZ -= sectorHeight * 0.75f; break;
+                }
+            }
+            else
+            {
+                switch (floorGradShift)
+                {
+                    case 1: shadeParams.lowerColorZ -= sectorHeight * 0.5f; break;
+                    case 2: shadeParams.lowerColorZ -= sectorHeight * 1.0f; break;
+                    case 3: shadeParams.lowerColorZ -= sectorHeight * 2.0f; break;
+                }
+
+                switch (ceilGradShift)
+                {
+                    case 1: shadeParams.upperColorZ += sectorHeight * 0.5f; break;
+                    case 2: shadeParams.upperColorZ += sectorHeight * 1.0f; break;
+                    case 3: shadeParams.upperColorZ += sectorHeight * 2.0f; break;
+                }
+            }
+        }
+
+        // [GEC] DC: dual color lighting calculation.
+        // Gets the color to use for the given Z (height) value and dual colored lighting params.
+        public static PixelColor GetColorForZ(float z, ShadingParams shadeParams)
+        {
+            // Same color? If so then don't do any interpolation:
+            if (shadeParams.lowerColor.Equals(shadeParams.upperColor))
+                return shadeParams.lowerColor;
+
+            // If there is zero or invalid sized z range then just return the floor color
+            float zRange = shadeParams.upperColorZ - shadeParams.lowerColorZ;
+
+            if (zRange <= 0.0f)
+                return shadeParams.lowerColor;
+
+            // Interpolate between the two colors based on z
+            float t = (z - shadeParams.lowerColorZ) / zRange;
+            return PixelColor.Lerp(shadeParams.lowerColor, shadeParams.upperColor, t);
         }
     }
 }

--- a/Source/Core/Map/Lights.cs
+++ b/Source/Core/Map/Lights.cs
@@ -13,48 +13,14 @@
 
 #endregion
 
-#region ================== Namespaces
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Drawing;
-using System.Collections.ObjectModel;
-using CodeImp.DoomBuilder.IO;
-using CodeImp.DoomBuilder.Geometry;
 using CodeImp.DoomBuilder.Rendering;
-using SlimDX.Direct3D9;
-using SlimDX;
-#endregion
 
 namespace CodeImp.DoomBuilder.Map
 {
-    public struct Lights
+    public static class Lights
     {
-        #region ================== Constants
-        #endregion
-
-        #region ================== Variables
-
-        // Properties
-        //private PixelColor[] colors;
-
-        #endregion
-
-        /*#region ================== Properties
-
-        public PixelColor this[int index] { get { return colors[index]; } }
-
-        #endregion*/
-
-        #region ================== Constructor / Disposer
-
-        public PixelColor GetLights(int index)
+        static readonly byte[] LIGHTS_DATA = new byte[]
         {
-            if (index == 0)
-                return new PixelColor(255, 255, 255, 255);
-
-            byte[] Lightmap = new byte[] {
             0xff, 0xff, 0xff, 0xD8, 0xDE, 0xE7, 0xC9, 0xD9, 0xE0, 0xBA, 0xD3, 0xDA,
             0xAB, 0xCE, 0xD3, 0x9B, 0xC8, 0xCD, 0x8C, 0xC3, 0xC6, 0x7D, 0xBD, 0xC0,
             0x6E, 0xB8, 0xB9, 0x5F, 0xB2, 0xB2, 0x50, 0xAD, 0xAC, 0x41, 0xA7, 0xA5,
@@ -118,16 +84,20 @@ namespace CodeImp.DoomBuilder.Map
             0x2A, 0x2F, 0x6B, 0x2C, 0x2C, 0x68, 0x2F, 0x28, 0x66, 0x30, 0x23, 0x62,
             0x31, 0x1F, 0x5D, 0x31, 0x1A, 0x59, 0x32, 0x15, 0x55, 0x33, 0x10, 0x50,
             0x34, 0x0C, 0x4C, 0x34, 0x07, 0x47, 0x35, 0x02, 0x43, 0x00, 0x00, 0x00,
-            0x8C, 0xB3, 0x8C, 0x05, 0x42, 0x94, 0xFF, 0xCD, 0x5A, 0xC9, 0x04, 0x04};
+            0x8C, 0xB3, 0x8C, 0x05, 0x42, 0x94, 0xFF, 0xCD, 0x5A, 0xC9, 0x04, 0x04
+        };
 
-            return new PixelColor(255, Lightmap[(index * 3)], Lightmap[(index * 3) + 1], Lightmap[(index * 3) + 2]);
+        public static PixelColor GetColor(int lightIdx)
+        {
+            if (lightIdx == 0)
+                return new PixelColor(255, 255, 255, 255);
+
+            return new PixelColor(
+                255,
+                LIGHTS_DATA[(lightIdx * 3)],
+                LIGHTS_DATA[(lightIdx * 3) + 1],
+                LIGHTS_DATA[(lightIdx * 3) + 2]
+            );
         }
-
-        #endregion
-
-        #region ================== Methods
-
-        #endregion
-
     }
 }

--- a/Source/Core/Map/MapSet.cs
+++ b/Source/Core/Map/MapSet.cs
@@ -2432,6 +2432,7 @@ namespace CodeImp.DoomBuilder.Map
 				s.CeilHeight = General.Settings.DefaultCeilingHeight;
 				s.Brightness = General.Settings.DefaultBrightness;
                 s.IdxColor = 0;//[GEC]
+				s.IdxColorCeil = 0;//[GEC]
             }
 
 			// Update line textures

--- a/Source/Core/Map/Sector.cs
+++ b/Source/Core/Map/Sector.cs
@@ -391,8 +391,7 @@ namespace CodeImp.DoomBuilder.Map
 
                 if (General.Map.PSXDOOM)//[GEC] Set Color On 2D View
                 {
-                    Lights col = new Lights();
-                    brightint = PixelColor.Modulate(PixelColor.FromInt(brightint), col.GetLights(idxcolor)).WithAlpha(255).ToInt();
+                    brightint = PixelColor.Modulate(PixelColor.FromInt(brightint), Lights.GetColor(idxcolor)).WithAlpha(255).ToInt();
                 }
 
                 // Make vertices

--- a/Source/Core/Map/Sector.cs
+++ b/Source/Core/Map/Sector.cs
@@ -69,6 +69,7 @@ namespace CodeImp.DoomBuilder.Map
 		private List<int> tags; //mxd
 		private int brightness;
         private int idxcolor;//[GEC]
+		private int idxcolorCeil;//[GEC] (ceiling color, if using Doom64 style 2 color lighting)
 
         //mxd. UDMF properties
         private Dictionary<string, bool> flags;
@@ -119,6 +120,7 @@ namespace CodeImp.DoomBuilder.Map
 		public List<int> Tags { get { return tags; } set { BeforePropsChange(); tags = value; } } //mxd
 		public int Brightness { get { return brightness; } set { BeforePropsChange(); brightness = value; updateneeded = true; } }
         public int IdxColor { get { return idxcolor; } set { BeforePropsChange(); idxcolor = value; updateneeded = true; } }//[GEC]
+		public int IdxColorCeil { get { return idxcolorCeil; } set { BeforePropsChange(); idxcolorCeil = value; updateneeded = true; } }//[GEC]
         public bool UpdateNeeded { get { return updateneeded; } set { updateneeded |= value; triangulationneeded |= value; } }
 		public RectangleF BBox { get { return bbox; } }
 		internal Sector Clone { get { return clone; } set { clone = value; } }
@@ -161,6 +163,7 @@ namespace CodeImp.DoomBuilder.Map
 			this.triangles = new Triangulation(); //mxd
 			this.surfaceentries = new SurfaceEntryCollection();
             this.idxcolor = 0;//[GEC]
+			this.idxcolorCeil = 0;//[GEC]
 
             if (map == General.Map.Map)
 				General.Map.UndoRedo.RecAddSector(this);
@@ -265,6 +268,7 @@ namespace CodeImp.DoomBuilder.Map
 			s.rwInt(ref effect);
 			s.rwInt(ref brightness);
             s.rwInt(ref idxcolor);//[GEC]
+			s.rwInt(ref idxcolorCeil);//[GEC]
 
             //mxd. (Re)store tags
             if (s.IsWriting) 
@@ -317,6 +321,7 @@ namespace CodeImp.DoomBuilder.Map
 			s.flags = new Dictionary<string, bool>(flags); //mxd
 			s.brightness = brightness;
             s.idxcolor = idxcolor;//[GEC]
+			s.idxcolorCeil = idxcolorCeil;//[GEC]
             s.flooroffset = flooroffset; //mxd
 			s.floorslope = floorslope; //mxd
 			s.ceiloffset = ceiloffset; //mxd
@@ -824,17 +829,17 @@ namespace CodeImp.DoomBuilder.Map
 		//mxd. This updates all properties (Doom/Hexen version)
 		public void Update(int hfloor, int hceil, string tfloor, string tceil, int effect, int tag, int brightness) 
 		{
-			Update(hfloor, hceil, tfloor, tceil, effect, new Dictionary<string, bool>(StringComparer.Ordinal), new List<int> { tag }, brightness, 0, new Vector3D(), 0, new Vector3D(), 0);//[GEC]
+			Update(hfloor, hceil, tfloor, tceil, effect, new Dictionary<string, bool>(StringComparer.Ordinal), new List<int> { tag }, brightness, 0, new Vector3D(), 0, new Vector3D(), 0, 0);//[GEC]
         }
 
-        //mxd. This updates all properties (Doom/Hexen version)
-        public void UpdatePsx(int hfloor, int hceil, string tfloor, string tceil, int effect, Dictionary<string, bool> flags, int tag, int brightness, int idxcolor) //[GEC]
+        //mxd. This updates all properties (PSX version, GEC)
+        public void UpdatePsx(int hfloor, int hceil, string tfloor, string tceil, int effect, Dictionary<string, bool> flags, int tag, int brightness, int idxcolor, int idxcolorCeil) //[GEC]
         {
-            Update(hfloor, hceil, tfloor, tceil, effect, flags, new List<int> { tag }, brightness, 0, new Vector3D(), 0, new Vector3D(), idxcolor);//[GEC]
+            Update(hfloor, hceil, tfloor, tceil, effect, flags, new List<int> { tag }, brightness, 0, new Vector3D(), 0, new Vector3D(), idxcolor, idxcolorCeil);//[GEC]
         }
 
         //mxd. This updates all properties (UDMF version)
-        public void Update(int hfloor, int hceil, string tfloor, string tceil, int effect, Dictionary<string, bool> flags, List<int> tags, int brightness, float flooroffset, Vector3D floorslope, float ceiloffset, Vector3D ceilslope, int idxcolor)//[GEC]
+        public void Update(int hfloor, int hceil, string tfloor, string tceil, int effect, Dictionary<string, bool> flags, List<int> tags, int brightness, float flooroffset, Vector3D floorslope, float ceiloffset, Vector3D ceilslope, int idxcolor, int idxcolorCeil)//[GEC]
 		{
 			BeforePropsChange();
 			
@@ -845,7 +850,8 @@ namespace CodeImp.DoomBuilder.Map
 			this.tags = new List<int>(tags); //mxd
 			this.flags = new Dictionary<string, bool>(flags); //mxd
 			this.brightness = brightness;
-            this.idxcolor = idxcolor;
+            this.idxcolor = idxcolor; //[GEC]
+			this.idxcolorCeil = idxcolorCeil; //[GEC]
             this.flooroffset = flooroffset; //mxd
 			this.floorslope = floorslope; //mxd
 			this.ceiloffset = ceiloffset; //mxd

--- a/Source/Core/Rendering/PixelColor.cs
+++ b/Source/Core/Rendering/PixelColor.cs
@@ -206,6 +206,24 @@ namespace CodeImp.DoomBuilder.Rendering
 			};
 		}
 
+		// [GEC] DC: Linear interpolation between two colors
+		public static PixelColor Lerp(PixelColor c1, PixelColor c2, float t)
+		{
+			float tinv = 1.0f - t;
+
+			float r = c1.r * tinv + c2.r * t + 0.5f;	// Note: +0.5 for rounding purposes
+			float g = c1.g * tinv + c2.g * t + 0.5f;
+			float b = c1.b * tinv + c2.b * t + 0.5f;
+			float a = c1.a * tinv + c2.a * t + 0.5f;
+
+			r = Math.Max(Math.Min(r, 255.0f), 0.0f);
+			g = Math.Max(Math.Min(g, 255.0f), 0.0f);
+			b = Math.Max(Math.Min(b, 255.0f), 0.0f);
+			a = Math.Max(Math.Min(a, 255.0f), 0.0f);
+
+			return new PixelColor((byte) a, (byte) r, (byte) g, (byte) b);
+		}
+
 		//mxd. Handy while debugging
 		public override string ToString()
 		{

--- a/Source/Core/Resources/world3d.fx
+++ b/Source/Core/Resources/world3d.fx
@@ -239,12 +239,11 @@ float getLightDiminishingMultiplier(float z)
 		intensity = 128.0;	// Things (no change)
 	}
 
-	// Clamp the intensity to the min/max allowed amounts (0.5x to 1.25x in normalized coords) and add a little
-	// bias to fix precision issues and flipping back and forth between values when the calculations are close:
-	intensity = trunc(clamp(intensity, 64.0, 160.0) + 0.0001);
+	// Clamp the intensity to the min/max allowed amounts (0.5x to 1.25x in normalized coords)
+	intensity = clamp(intensity, 64.0, 160.0);
 
-    // Scale the diminish intensity back to normalized color coords rather than 0-128
-    return intensity / 128.0;
+	// Scale the diminish intensity back to normalized color coords rather than 0-128
+	return intensity / 128.0;
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/Source/Core/Windows/LightColors.cs
+++ b/Source/Core/Windows/LightColors.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Windows.Forms;
-using CodeImp.DoomBuilder.Map;
+﻿using CodeImp.DoomBuilder.Map;
 using CodeImp.DoomBuilder.Rendering;
+using System;
+using System.Drawing;
+using System.Windows.Forms;
 
 namespace CodeImp.DoomBuilder.Windows
 {
@@ -23,8 +18,7 @@ namespace CodeImp.DoomBuilder.Windows
 
         private void LightColors_Load(object sender, EventArgs e)
         {
-            Lights Col = new Lights();//[GEC]
-            PixelColor rgb = Col.GetLights(0);
+            PixelColor rgb = Lights.GetColor(0); // [GEC]
 
             int index = 0;
             for (index = 0; index < 256; index++)//set color on boxes
@@ -33,7 +27,7 @@ namespace CodeImp.DoomBuilder.Windows
                 {
                     if (control.TabIndex == index)
                     {
-                        rgb = Col.GetLights(index);
+                        rgb = Lights.GetColor(index); // [GEC]
                         control.BackColor = Color.FromArgb(rgb.r, rgb.g, rgb.b);
                         control.Click += new System.EventHandler(this.Box_Click);
                         control.Cursor = System.Windows.Forms.Cursors.Hand;
@@ -48,7 +42,7 @@ namespace CodeImp.DoomBuilder.Windows
                 if (control.TabIndex == IindexCol)
                 {
                     ColorIndex.Text = IdxCol.ToString();
-                    rgb = Col.GetLights(IindexCol);
+                    rgb = Lights.GetColor(IindexCol); // [GEC]
                     panel257.Location = new System.Drawing.Point(control.Location.X + 2, control.Location.Y + 2);
                     panel257.BackColor = Color.FromArgb(rgb.r, rgb.g, rgb.b);
                     break;
@@ -61,8 +55,7 @@ namespace CodeImp.DoomBuilder.Windows
             panel256.BackColor = Color.FromArgb(255, 255, 0);
             Control control = (Control)sender;
 
-            Lights Col = new Lights();//[GEC]
-            PixelColor rgb = Col.GetLights(control.TabIndex);
+            PixelColor rgb = Lights.GetColor(control.TabIndex); // [GEC]
             panel256.BackColor = Color.FromArgb(rgb.r, rgb.g, rgb.b);
 
             //update color

--- a/Source/Core/Windows/SectorEditFormPSX.Designer.cs
+++ b/Source/Core/Windows/SectorEditFormPSX.Designer.cs
@@ -29,30 +29,30 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            System.Windows.Forms.Label label1;
-            System.Windows.Forms.Label label3;
-            System.Windows.Forms.GroupBox groupfloorceiling;
-            System.Windows.Forms.Label label7;
-            System.Windows.Forms.Label label5;
-            System.Windows.Forms.Label label6;
-            System.Windows.Forms.Label label9;
-            System.Windows.Forms.Label label2;
-            System.Windows.Forms.Label label4;
-            System.Windows.Forms.GroupBox groupeffect;
-            System.Windows.Forms.Label label8;
+            this.label1 = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
+            this.groupfloorceiling = new System.Windows.Forms.GroupBox();
             this.label10 = new System.Windows.Forms.Label();
             this.panel = new System.Windows.Forms.Panel();
             this.idxcolor = new CodeImp.DoomBuilder.Controls.ButtonsNumericTextbox();
+            this.label7 = new System.Windows.Forms.Label();
+            this.label5 = new System.Windows.Forms.Label();
+            this.label6 = new System.Windows.Forms.Label();
             this.heightoffset = new CodeImp.DoomBuilder.Controls.ButtonsNumericTextbox();
             this.brightness = new CodeImp.DoomBuilder.Controls.ButtonsNumericTextbox();
             this.ceilingheight = new CodeImp.DoomBuilder.Controls.ButtonsNumericTextbox();
+            this.label9 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
             this.sectorheightlabel = new System.Windows.Forms.Label();
+            this.label4 = new System.Windows.Forms.Label();
             this.sectorheight = new System.Windows.Forms.Label();
             this.floortex = new CodeImp.DoomBuilder.Controls.FlatSelectorControl();
             this.floorheight = new CodeImp.DoomBuilder.Controls.ButtonsNumericTextbox();
             this.ceilingtex = new CodeImp.DoomBuilder.Controls.FlatSelectorControl();
+            this.groupeffect = new System.Windows.Forms.GroupBox();
             this.browseeffect = new System.Windows.Forms.Button();
             this.effect = new CodeImp.DoomBuilder.Controls.ActionSelectorControl();
+            this.label8 = new System.Windows.Forms.Label();
             this.tagSelector = new CodeImp.DoomBuilder.Controls.TagSelector();
             this.tooltip = new System.Windows.Forms.ToolTip(this.components);
             this.apply = new System.Windows.Forms.Button();
@@ -60,67 +60,56 @@
             this.panel1 = new System.Windows.Forms.Panel();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
             this.flags = new CodeImp.DoomBuilder.Controls.CheckboxArrayControl();
-            label1 = new System.Windows.Forms.Label();
-            label3 = new System.Windows.Forms.Label();
-            groupfloorceiling = new System.Windows.Forms.GroupBox();
-            label7 = new System.Windows.Forms.Label();
-            label5 = new System.Windows.Forms.Label();
-            label6 = new System.Windows.Forms.Label();
-            label9 = new System.Windows.Forms.Label();
-            label2 = new System.Windows.Forms.Label();
-            label4 = new System.Windows.Forms.Label();
-            groupeffect = new System.Windows.Forms.GroupBox();
-            label8 = new System.Windows.Forms.Label();
-            groupfloorceiling.SuspendLayout();
-            groupeffect.SuspendLayout();
+            this.groupfloorceiling.SuspendLayout();
+            this.groupeffect.SuspendLayout();
             this.panel1.SuspendLayout();
             this.groupBox3.SuspendLayout();
             this.SuspendLayout();
             // 
             // label1
             // 
-            label1.Location = new System.Drawing.Point(271, 18);
-            label1.Name = "label1";
-            label1.Size = new System.Drawing.Size(83, 16);
-            label1.TabIndex = 15;
-            label1.Text = "Floor";
-            label1.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.label1.Location = new System.Drawing.Point(271, 18);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(83, 16);
+            this.label1.TabIndex = 15;
+            this.label1.Text = "Floor";
+            this.label1.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
             // label3
             // 
-            label3.Location = new System.Drawing.Point(363, 18);
-            label3.Name = "label3";
-            label3.Size = new System.Drawing.Size(83, 16);
-            label3.TabIndex = 14;
-            label3.Text = "Ceiling";
-            label3.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.label3.Location = new System.Drawing.Point(363, 18);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(83, 16);
+            this.label3.TabIndex = 14;
+            this.label3.Text = "Ceiling";
+            this.label3.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
             // groupfloorceiling
             // 
-            groupfloorceiling.BackColor = System.Drawing.Color.Transparent;
-            groupfloorceiling.Controls.Add(this.label10);
-            groupfloorceiling.Controls.Add(this.panel);
-            groupfloorceiling.Controls.Add(this.idxcolor);
-            groupfloorceiling.Controls.Add(label7);
-            groupfloorceiling.Controls.Add(label5);
-            groupfloorceiling.Controls.Add(label6);
-            groupfloorceiling.Controls.Add(this.heightoffset);
-            groupfloorceiling.Controls.Add(this.brightness);
-            groupfloorceiling.Controls.Add(this.ceilingheight);
-            groupfloorceiling.Controls.Add(label9);
-            groupfloorceiling.Controls.Add(label2);
-            groupfloorceiling.Controls.Add(this.sectorheightlabel);
-            groupfloorceiling.Controls.Add(label4);
-            groupfloorceiling.Controls.Add(this.sectorheight);
-            groupfloorceiling.Controls.Add(this.floortex);
-            groupfloorceiling.Controls.Add(this.floorheight);
-            groupfloorceiling.Controls.Add(this.ceilingtex);
-            groupfloorceiling.Location = new System.Drawing.Point(3, 3);
-            groupfloorceiling.Name = "groupfloorceiling";
-            groupfloorceiling.Size = new System.Drawing.Size(436, 214);
-            groupfloorceiling.TabIndex = 0;
-            groupfloorceiling.TabStop = false;
-            groupfloorceiling.Text = "Floor and ceiling ";
+            this.groupfloorceiling.BackColor = System.Drawing.Color.Transparent;
+            this.groupfloorceiling.Controls.Add(this.label10);
+            this.groupfloorceiling.Controls.Add(this.panel);
+            this.groupfloorceiling.Controls.Add(this.idxcolor);
+            this.groupfloorceiling.Controls.Add(this.label7);
+            this.groupfloorceiling.Controls.Add(this.label5);
+            this.groupfloorceiling.Controls.Add(this.label6);
+            this.groupfloorceiling.Controls.Add(this.heightoffset);
+            this.groupfloorceiling.Controls.Add(this.brightness);
+            this.groupfloorceiling.Controls.Add(this.ceilingheight);
+            this.groupfloorceiling.Controls.Add(this.label9);
+            this.groupfloorceiling.Controls.Add(this.label2);
+            this.groupfloorceiling.Controls.Add(this.sectorheightlabel);
+            this.groupfloorceiling.Controls.Add(this.label4);
+            this.groupfloorceiling.Controls.Add(this.sectorheight);
+            this.groupfloorceiling.Controls.Add(this.floortex);
+            this.groupfloorceiling.Controls.Add(this.floorheight);
+            this.groupfloorceiling.Controls.Add(this.ceilingtex);
+            this.groupfloorceiling.Location = new System.Drawing.Point(3, 3);
+            this.groupfloorceiling.Name = "groupfloorceiling";
+            this.groupfloorceiling.Size = new System.Drawing.Size(436, 214);
+            this.groupfloorceiling.TabIndex = 0;
+            this.groupfloorceiling.TabStop = false;
+            this.groupfloorceiling.Text = "Floor and ceiling ";
             // 
             // label10
             // 
@@ -164,34 +153,34 @@
             // 
             // label7
             // 
-            label7.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            label7.ForeColor = System.Drawing.SystemColors.HotTrack;
-            label7.Location = new System.Drawing.Point(16, 100);
-            label7.Name = "label7";
-            label7.Size = new System.Drawing.Size(78, 14);
-            label7.TabIndex = 25;
-            label7.Text = "Height offset:";
-            label7.TextAlign = System.Drawing.ContentAlignment.TopRight;
-            this.tooltip.SetToolTip(label7, "Changes floor and ceiling height by given value.\r\nUse \"++\" to raise by sector hei" +
+            this.label7.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label7.ForeColor = System.Drawing.SystemColors.HotTrack;
+            this.label7.Location = new System.Drawing.Point(16, 100);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(78, 14);
+            this.label7.TabIndex = 25;
+            this.label7.Text = "Height offset:";
+            this.label7.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            this.tooltip.SetToolTip(this.label7, "Changes floor and ceiling height by given value.\r\nUse \"++\" to raise by sector hei" +
         "ght.\r\nUse \"--\" to lower by sector height.");
             // 
             // label5
             // 
-            label5.Location = new System.Drawing.Point(16, 70);
-            label5.Name = "label5";
-            label5.Size = new System.Drawing.Size(78, 14);
-            label5.TabIndex = 17;
-            label5.Text = "Floor height:";
-            label5.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            this.label5.Location = new System.Drawing.Point(16, 70);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(78, 14);
+            this.label5.TabIndex = 17;
+            this.label5.Text = "Floor height:";
+            this.label5.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
             // label6
             // 
-            label6.Location = new System.Drawing.Point(16, 40);
-            label6.Name = "label6";
-            label6.Size = new System.Drawing.Size(78, 14);
-            label6.TabIndex = 19;
-            label6.Text = "Ceiling height:";
-            label6.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            this.label6.Location = new System.Drawing.Point(16, 40);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(78, 14);
+            this.label6.TabIndex = 19;
+            this.label6.Text = "Ceiling height:";
+            this.label6.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
             // heightoffset
             // 
@@ -252,22 +241,22 @@
             // 
             // label9
             // 
-            label9.Location = new System.Drawing.Point(15, 159);
-            label9.Name = "label9";
-            label9.Size = new System.Drawing.Size(78, 14);
-            label9.TabIndex = 2;
-            label9.Text = "Brightness:";
-            label9.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            this.label9.Location = new System.Drawing.Point(15, 159);
+            this.label9.Name = "label9";
+            this.label9.Size = new System.Drawing.Size(78, 14);
+            this.label9.TabIndex = 2;
+            this.label9.Text = "Brightness:";
+            this.label9.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
             // label2
             // 
-            label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            label2.Location = new System.Drawing.Point(196, 16);
-            label2.Name = "label2";
-            label2.Size = new System.Drawing.Size(114, 16);
-            label2.TabIndex = 15;
-            label2.Text = "Floor";
-            label2.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.label2.Location = new System.Drawing.Point(196, 16);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(114, 16);
+            this.label2.TabIndex = 15;
+            this.label2.Text = "Floor";
+            this.label2.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
             // sectorheightlabel
             // 
@@ -280,13 +269,13 @@
             // 
             // label4
             // 
-            label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            label4.Location = new System.Drawing.Point(316, 16);
-            label4.Name = "label4";
-            label4.Size = new System.Drawing.Size(114, 16);
-            label4.TabIndex = 14;
-            label4.Text = "Ceiling";
-            label4.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.label4.Location = new System.Drawing.Point(316, 16);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(114, 16);
+            this.label4.TabIndex = 14;
+            this.label4.Text = "Ceiling";
+            this.label4.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
             // sectorheight
             // 
@@ -338,17 +327,17 @@
             // 
             // groupeffect
             // 
-            groupeffect.BackColor = System.Drawing.Color.Transparent;
-            groupeffect.Controls.Add(this.browseeffect);
-            groupeffect.Controls.Add(this.effect);
-            groupeffect.Controls.Add(label8);
-            groupeffect.Controls.Add(this.tagSelector);
-            groupeffect.Location = new System.Drawing.Point(4, 223);
-            groupeffect.Name = "groupeffect";
-            groupeffect.Size = new System.Drawing.Size(436, 92);
-            groupeffect.TabIndex = 1;
-            groupeffect.TabStop = false;
-            groupeffect.Text = "Effect and identification";
+            this.groupeffect.BackColor = System.Drawing.Color.Transparent;
+            this.groupeffect.Controls.Add(this.browseeffect);
+            this.groupeffect.Controls.Add(this.effect);
+            this.groupeffect.Controls.Add(this.label8);
+            this.groupeffect.Controls.Add(this.tagSelector);
+            this.groupeffect.Location = new System.Drawing.Point(4, 223);
+            this.groupeffect.Name = "groupeffect";
+            this.groupeffect.Size = new System.Drawing.Size(436, 92);
+            this.groupeffect.TabIndex = 1;
+            this.groupeffect.TabStop = false;
+            this.groupeffect.Text = "Effect and identification";
             // 
             // browseeffect
             // 
@@ -376,12 +365,12 @@
             // 
             // label8
             // 
-            label8.AutoSize = true;
-            label8.Location = new System.Drawing.Point(12, 31);
-            label8.Name = "label8";
-            label8.Size = new System.Drawing.Size(45, 13);
-            label8.TabIndex = 0;
-            label8.Text = "Special:";
+            this.label8.AutoSize = true;
+            this.label8.Location = new System.Drawing.Point(12, 31);
+            this.label8.Name = "label8";
+            this.label8.Size = new System.Drawing.Size(45, 13);
+            this.label8.TabIndex = 0;
+            this.label8.Text = "Special:";
             // 
             // tagSelector
             // 
@@ -423,8 +412,8 @@
             // panel1
             // 
             this.panel1.BackColor = System.Drawing.SystemColors.Control;
-            this.panel1.Controls.Add(groupfloorceiling);
-            this.panel1.Controls.Add(groupeffect);
+            this.panel1.Controls.Add(this.groupfloorceiling);
+            this.panel1.Controls.Add(this.groupeffect);
             this.panel1.Location = new System.Drawing.Point(12, 10);
             this.panel1.Name = "panel1";
             this.panel1.Size = new System.Drawing.Size(443, 320);
@@ -442,8 +431,8 @@
             // 
             // flags
             // 
-            this.flags.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-            | System.Windows.Forms.AnchorStyles.Left)
+            this.flags.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.flags.AutoScroll = true;
             this.flags.Columns = 2;
@@ -474,10 +463,10 @@
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Edit Sector";
             this.HelpRequested += new System.Windows.Forms.HelpEventHandler(this.SectorEditFormPSX_HelpRequested);
-            groupfloorceiling.ResumeLayout(false);
-            groupfloorceiling.PerformLayout();
-            groupeffect.ResumeLayout(false);
-            groupeffect.PerformLayout();
+            this.groupfloorceiling.ResumeLayout(false);
+            this.groupfloorceiling.PerformLayout();
+            this.groupeffect.ResumeLayout(false);
+            this.groupeffect.PerformLayout();
             this.panel1.ResumeLayout(false);
             this.groupBox3.ResumeLayout(false);
             this.ResumeLayout(false);
@@ -506,5 +495,16 @@
         private System.Windows.Forms.Label label10;
         private System.Windows.Forms.GroupBox groupBox3;
         private Controls.CheckboxArrayControl flags;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.GroupBox groupfloorceiling;
+        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.Label label9;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.GroupBox groupeffect;
+        private System.Windows.Forms.Label label8;
     }
 }

--- a/Source/Core/Windows/SectorEditFormPSX.Designer.cs
+++ b/Source/Core/Windows/SectorEditFormPSX.Designer.cs
@@ -435,7 +435,7 @@
             // apply
             // 
             this.apply.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.apply.Location = new System.Drawing.Point(225, 415);
+            this.apply.Location = new System.Drawing.Point(225, 445);
             this.apply.Name = "apply";
             this.apply.Size = new System.Drawing.Size(112, 25);
             this.apply.TabIndex = 1;
@@ -447,7 +447,7 @@
             // 
             this.cancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.cancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cancel.Location = new System.Drawing.Point(343, 415);
+            this.cancel.Location = new System.Drawing.Point(343, 445);
             this.cancel.Name = "cancel";
             this.cancel.Size = new System.Drawing.Size(112, 25);
             this.cancel.TabIndex = 2;
@@ -470,7 +470,7 @@
             this.groupBox3.Controls.Add(this.flags);
             this.groupBox3.Location = new System.Drawing.Point(12, 336);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(443, 73);
+            this.groupBox3.Size = new System.Drawing.Size(443, 103);
             this.groupBox3.TabIndex = 4;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = " Flags ";
@@ -484,7 +484,7 @@
             this.flags.Columns = 2;
             this.flags.Location = new System.Drawing.Point(15, 21);
             this.flags.Name = "flags";
-            this.flags.Size = new System.Drawing.Size(422, 46);
+            this.flags.Size = new System.Drawing.Size(422, 76);
             this.flags.TabIndex = 0;
             this.flags.VerticalSpacing = 1;
             // 
@@ -494,7 +494,7 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.CancelButton = this.cancel;
-            this.ClientSize = new System.Drawing.Size(466, 451);
+            this.ClientSize = new System.Drawing.Size(466, 481);
             this.Controls.Add(this.groupBox3);
             this.Controls.Add(this.panel1);
             this.Controls.Add(this.cancel);

--- a/Source/Core/Windows/SectorEditFormPSX.Designer.cs
+++ b/Source/Core/Windows/SectorEditFormPSX.Designer.cs
@@ -33,7 +33,7 @@
             this.label3 = new System.Windows.Forms.Label();
             this.groupfloorceiling = new System.Windows.Forms.GroupBox();
             this.label10 = new System.Windows.Forms.Label();
-            this.label11 = new System.Windows.Forms.Label();
+            this.lblSectorColorCeil = new System.Windows.Forms.Label();
             this.pnlSectorColor = new System.Windows.Forms.Panel();
             this.pnlSectorColorCeil = new System.Windows.Forms.Panel();
             this.idxcolor = new CodeImp.DoomBuilder.Controls.ButtonsNumericTextbox();
@@ -91,7 +91,7 @@
             // 
             this.groupfloorceiling.BackColor = System.Drawing.Color.Transparent;
             this.groupfloorceiling.Controls.Add(this.label10);
-            this.groupfloorceiling.Controls.Add(this.label11);
+            this.groupfloorceiling.Controls.Add(this.lblSectorColorCeil);
             this.groupfloorceiling.Controls.Add(this.pnlSectorColor);
             this.groupfloorceiling.Controls.Add(this.pnlSectorColorCeil);
             this.groupfloorceiling.Controls.Add(this.idxcolor);
@@ -127,15 +127,15 @@
             this.label10.Text = "Sector color by index:";
             this.label10.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
-            // label11
+            // lblSectorColorCeil
             // 
-            this.label11.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label11.Location = new System.Drawing.Point(234, 181);
-            this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(76, 27);
-            this.label11.TabIndex = 31;
-            this.label11.Text = "Ceiling sector color by index:";
-            this.label11.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            this.lblSectorColorCeil.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblSectorColorCeil.Location = new System.Drawing.Point(234, 181);
+            this.lblSectorColorCeil.Name = "lblSectorColorCeil";
+            this.lblSectorColorCeil.Size = new System.Drawing.Size(76, 27);
+            this.lblSectorColorCeil.TabIndex = 31;
+            this.lblSectorColorCeil.Text = "Ceiling sector color by index:";
+            this.lblSectorColorCeil.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
             // pnlSectorColor
             // 
@@ -553,7 +553,7 @@
         private System.Windows.Forms.GroupBox groupeffect;
         private System.Windows.Forms.Label label8;
         private Controls.ButtonsNumericTextbox idxcolorCeil;
-        private System.Windows.Forms.Label label11;
+        private System.Windows.Forms.Label lblSectorColorCeil;
         private System.Windows.Forms.Panel pnlSectorColorCeil;
     }
 }

--- a/Source/Core/Windows/SectorEditFormPSX.Designer.cs
+++ b/Source/Core/Windows/SectorEditFormPSX.Designer.cs
@@ -33,8 +33,11 @@
             this.label3 = new System.Windows.Forms.Label();
             this.groupfloorceiling = new System.Windows.Forms.GroupBox();
             this.label10 = new System.Windows.Forms.Label();
-            this.panel = new System.Windows.Forms.Panel();
+            this.label11 = new System.Windows.Forms.Label();
+            this.pnlSectorColor = new System.Windows.Forms.Panel();
+            this.pnlSectorColorCeil = new System.Windows.Forms.Panel();
             this.idxcolor = new CodeImp.DoomBuilder.Controls.ButtonsNumericTextbox();
+            this.idxcolorCeil = new CodeImp.DoomBuilder.Controls.ButtonsNumericTextbox();
             this.label7 = new System.Windows.Forms.Label();
             this.label5 = new System.Windows.Forms.Label();
             this.label6 = new System.Windows.Forms.Label();
@@ -88,8 +91,11 @@
             // 
             this.groupfloorceiling.BackColor = System.Drawing.Color.Transparent;
             this.groupfloorceiling.Controls.Add(this.label10);
-            this.groupfloorceiling.Controls.Add(this.panel);
+            this.groupfloorceiling.Controls.Add(this.label11);
+            this.groupfloorceiling.Controls.Add(this.pnlSectorColor);
+            this.groupfloorceiling.Controls.Add(this.pnlSectorColorCeil);
             this.groupfloorceiling.Controls.Add(this.idxcolor);
+            this.groupfloorceiling.Controls.Add(this.idxcolorCeil);
             this.groupfloorceiling.Controls.Add(this.label7);
             this.groupfloorceiling.Controls.Add(this.label5);
             this.groupfloorceiling.Controls.Add(this.label6);
@@ -121,16 +127,37 @@
             this.label10.Text = "Sector color by index:";
             this.label10.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
-            // panel
+            // label11
             // 
-            this.panel.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(128)))), ((int)(((byte)(0)))));
-            this.panel.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
-            this.panel.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.panel.Location = new System.Drawing.Point(178, 188);
-            this.panel.Name = "panel";
-            this.panel.Size = new System.Drawing.Size(20, 20);
-            this.panel.TabIndex = 29;
-            this.panel.Click += new System.EventHandler(this.drawfrom);
+            this.label11.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label11.Location = new System.Drawing.Point(234, 181);
+            this.label11.Name = "label11";
+            this.label11.Size = new System.Drawing.Size(76, 27);
+            this.label11.TabIndex = 31;
+            this.label11.Text = "Ceiling sector color by index:";
+            this.label11.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // pnlSectorColor
+            // 
+            this.pnlSectorColor.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(128)))), ((int)(((byte)(0)))));
+            this.pnlSectorColor.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+            this.pnlSectorColor.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.pnlSectorColor.Location = new System.Drawing.Point(178, 188);
+            this.pnlSectorColor.Name = "pnlSectorColor";
+            this.pnlSectorColor.Size = new System.Drawing.Size(20, 20);
+            this.pnlSectorColor.TabIndex = 29;
+            this.pnlSectorColor.Click += new System.EventHandler(this.drawfrom);
+            // 
+            // pnlSectorColorCeil
+            // 
+            this.pnlSectorColorCeil.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(128)))), ((int)(((byte)(0)))));
+            this.pnlSectorColorCeil.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+            this.pnlSectorColorCeil.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.pnlSectorColorCeil.Location = new System.Drawing.Point(398, 188);
+            this.pnlSectorColorCeil.Name = "pnlSectorColorCeil";
+            this.pnlSectorColorCeil.Size = new System.Drawing.Size(20, 20);
+            this.pnlSectorColorCeil.TabIndex = 30;
+            this.pnlSectorColorCeil.Click += new System.EventHandler(this.drawfromCeil);
             // 
             // idxcolor
             // 
@@ -150,6 +177,25 @@
             this.idxcolor.StepValues = null;
             this.idxcolor.TabIndex = 28;
             this.idxcolor.WhenTextChanged += new System.EventHandler(this.IdxColor_WhenTextChanged);
+            // 
+            // idxcolorCeil
+            // 
+            this.idxcolorCeil.AllowDecimal = false;
+            this.idxcolorCeil.AllowExpressions = false;
+            this.idxcolorCeil.AllowNegative = true;
+            this.idxcolorCeil.AllowRelative = true;
+            this.idxcolorCeil.ButtonStep = 1;
+            this.idxcolorCeil.ButtonStepBig = 16F;
+            this.idxcolorCeil.ButtonStepFloat = 1F;
+            this.idxcolorCeil.ButtonStepSmall = 1F;
+            this.idxcolorCeil.ButtonStepsUseModifierKeys = true;
+            this.idxcolorCeil.ButtonStepsWrapAround = false;
+            this.idxcolorCeil.Location = new System.Drawing.Point(319, 184);
+            this.idxcolorCeil.Name = "idxcolorCeil";
+            this.idxcolorCeil.Size = new System.Drawing.Size(73, 24);
+            this.idxcolorCeil.StepValues = null;
+            this.idxcolorCeil.TabIndex = 32;
+            this.idxcolorCeil.WhenTextChanged += new System.EventHandler(this.IdxColorCeil_WhenTextChanged);
             // 
             // label7
             // 
@@ -491,7 +537,7 @@
         private CodeImp.DoomBuilder.Controls.ButtonsNumericTextbox heightoffset;
         private System.Windows.Forms.ToolTip tooltip;
         private Controls.ButtonsNumericTextbox idxcolor;
-        private System.Windows.Forms.Panel panel;
+        private System.Windows.Forms.Panel pnlSectorColor;
         private System.Windows.Forms.Label label10;
         private System.Windows.Forms.GroupBox groupBox3;
         private Controls.CheckboxArrayControl flags;
@@ -506,5 +552,8 @@
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.GroupBox groupeffect;
         private System.Windows.Forms.Label label8;
+        private Controls.ButtonsNumericTextbox idxcolorCeil;
+        private System.Windows.Forms.Label label11;
+        private System.Windows.Forms.Panel pnlSectorColorCeil;
     }
 }

--- a/Source/Core/Windows/SectorEditFormPSX.cs
+++ b/Source/Core/Windows/SectorEditFormPSX.cs
@@ -183,10 +183,9 @@ namespace CodeImp.DoomBuilder.Windows
                 //mxd. Store initial properties
                 sectorprops.Add(new SectorProperties(s));
 
-                // Apply new color
-                Lights Col = new Lights();//[GEC]
-                PixelColor rgb = Col.GetLights(s.IdxColor);
-                PixelColor rgbCeil = Col.GetLights(s.IdxColorCeil);
+                // [GEC] Apply new color
+                PixelColor rgb = Lights.GetColor(s.IdxColor);
+                PixelColor rgbCeil = Lights.GetColor(s.IdxColorCeil);
                 pnlSectorColor.BackColor = Color.FromArgb(rgb.r, rgb.g, rgb.b);
                 pnlSectorColorCeil.BackColor = Color.FromArgb(rgbCeil.r, rgbCeil.g, rgbCeil.b);
             }
@@ -538,7 +537,6 @@ namespace CodeImp.DoomBuilder.Windows
             if (preventchanges) return;
             MakeUndo(); //mxd
             int i = 0;
-            Lights Col = new Lights();//[GEC]
 
             //restore values
             if (string.IsNullOrEmpty(idxcolor.Text))
@@ -547,7 +545,7 @@ namespace CodeImp.DoomBuilder.Windows
                 {
                     s.IdxColor = sectorprops[i++].IdxColor;
                     // Apply new color
-                    PixelColor rgb = Col.GetLights(s.IdxColor);
+                    PixelColor rgb = Lights.GetColor(s.IdxColor);
                     pnlSectorColor.BackColor = Color.FromArgb(rgb.r, rgb.g, rgb.b);//frm.Color;
                 }
 
@@ -558,7 +556,7 @@ namespace CodeImp.DoomBuilder.Windows
                 {
                     s.IdxColor = General.Clamp(idxcolor.GetResult(sectorprops[i++].IdxColor), 0, 255);
                     // Apply new color
-                    PixelColor rgb = Col.GetLights(s.IdxColor);
+                    PixelColor rgb = Lights.GetColor(s.IdxColor);
                     pnlSectorColor.BackColor = Color.FromArgb(rgb.r, rgb.g, rgb.b);//frm.Color;
                 }
             }
@@ -572,7 +570,6 @@ namespace CodeImp.DoomBuilder.Windows
             if (preventchanges) return;
             MakeUndo(); //mxd
             int i = 0;
-            Lights Col = new Lights();//[GEC]
 
             //restore values
             if (string.IsNullOrEmpty(idxcolorCeil.Text))
@@ -581,7 +578,7 @@ namespace CodeImp.DoomBuilder.Windows
                 {
                     s.IdxColorCeil = sectorprops[i++].IdxColorCeil;
                     // Apply new color
-                    PixelColor rgb = Col.GetLights(s.IdxColorCeil);
+                    PixelColor rgb = Lights.GetColor(s.IdxColorCeil);
                     pnlSectorColorCeil.BackColor = Color.FromArgb(rgb.r, rgb.g, rgb.b);//frm.Color;
                 }
 
@@ -592,7 +589,7 @@ namespace CodeImp.DoomBuilder.Windows
                 {
                     s.IdxColorCeil = General.Clamp(idxcolorCeil.GetResult(sectorprops[i++].IdxColorCeil), 0, 255);
                     // Apply new color
-                    PixelColor rgb = Col.GetLights(s.IdxColorCeil);
+                    PixelColor rgb = Lights.GetColor(s.IdxColorCeil);
                     pnlSectorColorCeil.BackColor = Color.FromArgb(rgb.r, rgb.g, rgb.b);//frm.Color;
                 }
             }
@@ -608,10 +605,9 @@ namespace CodeImp.DoomBuilder.Windows
 
             if (frm.ShowDialog(this.ParentForm) == DialogResult.OK)
             {
-                // Apply new color
-                Lights Col = new Lights();//[GEC]
-                PixelColor rgb = Col.GetLights(frm.IindexCol);
-                idxcolor.Text = frm.IdxCol.ToString();//[GEC]
+                // [GEC] Apply new color
+                PixelColor rgb = Lights.GetColor(frm.IindexCol);
+                idxcolor.Text = frm.IdxCol.ToString();
                 pnlSectorColor.BackColor = Color.FromArgb(rgb.r, rgb.g, rgb.b);
             }
         }
@@ -623,10 +619,9 @@ namespace CodeImp.DoomBuilder.Windows
 
             if (frm.ShowDialog(this.ParentForm) == DialogResult.OK)
             {
-                // Apply new color
-                Lights Col = new Lights();//[GEC]
-                PixelColor rgb = Col.GetLights(frm.IindexCol);
-                idxcolorCeil.Text = frm.IdxCol.ToString();//[GEC]
+                // [GEC] Apply new color
+                PixelColor rgb = Lights.GetColor(frm.IindexCol);
+                idxcolorCeil.Text = frm.IdxCol.ToString();
                 pnlSectorColorCeil.BackColor = Color.FromArgb(rgb.r, rgb.g, rgb.b);
             }
         }

--- a/Source/Core/Windows/SectorEditFormPSX.cs
+++ b/Source/Core/Windows/SectorEditFormPSX.cs
@@ -190,6 +190,13 @@ namespace CodeImp.DoomBuilder.Windows
                 pnlSectorColorCeil.BackColor = Color.FromArgb(rgbCeil.r, rgbCeil.g, rgbCeil.b);
             }
 
+            // Enable or disable the ceiling color setting depending on whether dual colored lighting is allowed
+            bool useDualColoredLighting = General.Map.Config.PSXDOOM_DCLIGHTS;
+
+            this.pnlSectorColorCeil.Visible = useDualColoredLighting;
+            this.idxcolorCeil.Visible = useDualColoredLighting;
+            this.lblSectorColorCeil.Visible = useDualColoredLighting;
+
             // Show sector height
             UpdateSectorHeight();
 

--- a/Source/Core/Windows/SectorEditFormPSX.resx
+++ b/Source/Core/Windows/SectorEditFormPSX.resx
@@ -120,7 +120,4 @@
   <metadata name="tooltip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="tooltip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
 </root>

--- a/Source/Core/Windows/SectorEditFormPSX.resx
+++ b/Source/Core/Windows/SectorEditFormPSX.resx
@@ -120,4 +120,7 @@
   <metadata name="tooltip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="tooltip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/Source/Core/Windows/SectorEditFormPSX.resx
+++ b/Source/Core/Windows/SectorEditFormPSX.resx
@@ -117,4 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="tooltip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="tooltip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySidedef.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySidedef.cs
@@ -216,8 +216,11 @@ namespace CodeImp.DoomBuilder.BuilderModes
 							{
 								if(l.type == SectorLevelType.Glow)
 								{
-									//mxd. Glow levels should not affect light level
-									np.color = p.color;
+									// mxd. Glow levels should not affect light level
+									np.lowerColor = p.lowerColor; // [GEC]
+									np.upperColor = p.upperColor; // [GEC]
+									np.lowerColorZ = p.lowerColorZ; // [GEC]
+									np.upperColorZ = p.upperColorZ; // [GEC]
 								}
 								else
 								{
@@ -232,7 +235,10 @@ namespace CodeImp.DoomBuilder.BuilderModes
 										lightlevel = l.brightnessbelow;
 
 									PixelColor wallbrightness = PixelColor.FromInt(mode.CalculateBrightness(lightlevel, Sidedef)); //mxd
-									np.color = PixelColor.Modulate(l.colorbelow, wallbrightness).WithAlpha(255).ToInt();
+									np.lowerColor = PixelColor.Modulate(l.colorbelow, wallbrightness).WithAlpha(255); // [GEC]
+									np.upperColor = np.lowerColor; // [GEC]
+									np.lowerColorZ = p.lowerColorZ; // [GEC]
+									np.upperColorZ = p.upperColorZ; // [GEC]
 								}
 
 								if(p.Count == 0)
@@ -270,9 +276,16 @@ namespace CodeImp.DoomBuilder.BuilderModes
 				{
 					for(int k = 1; k < (p.Count - 1); k++)
 					{
-						verts.Add(new WorldVertex(p[0], p.color, texc[0]));
-						verts.Add(new WorldVertex(p[k], p.color, texc[k]));
-						verts.Add(new WorldVertex(p[k + 1], p.color, texc[k + 1]));
+						Vector3D p1 = p[0];	// [GEC]
+						Vector3D p2 = p[k];
+						Vector3D p3 = p[k + 1];
+						int c1 = WallPolygon.GetColorForZ(p1.z, p).ToInt();
+						int c2 = WallPolygon.GetColorForZ(p2.z, p).ToInt();
+						int c3 = WallPolygon.GetColorForZ(p3.z, p).ToInt();
+
+						verts.Add(new WorldVertex(p1, c1, texc[0]));
+						verts.Add(new WorldVertex(p2, c2, texc[k]));
+						verts.Add(new WorldVertex(p3, c3, texc[k + 1]));
 					}
 				}
 			}

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySidedef.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySidedef.cs
@@ -217,10 +217,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 								if(l.type == SectorLevelType.Glow)
 								{
 									// mxd. Glow levels should not affect light level
-									np.lowerColor = p.lowerColor; // [GEC]
-									np.upperColor = p.upperColor; // [GEC]
-									np.lowerColorZ = p.lowerColorZ; // [GEC]
-									np.upperColorZ = p.upperColorZ; // [GEC]
+									np.shadeParams = p.shadeParams; // [GEC]
 								}
 								else
 								{
@@ -235,10 +232,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 										lightlevel = l.brightnessbelow;
 
 									PixelColor wallbrightness = PixelColor.FromInt(mode.CalculateBrightness(lightlevel, Sidedef)); //mxd
-									np.lowerColor = PixelColor.Modulate(l.colorbelow, wallbrightness).WithAlpha(255); // [GEC]
-									np.upperColor = np.lowerColor; // [GEC]
-									np.lowerColorZ = p.lowerColorZ; // [GEC]
-									np.upperColorZ = p.upperColorZ; // [GEC]
+									np.SetShadingParams(l.sector, PixelColor.Modulate(l.colorbelow, wallbrightness).WithAlpha(255)); // [GEC]
 								}
 
 								if(p.Count == 0)
@@ -279,9 +273,9 @@ namespace CodeImp.DoomBuilder.BuilderModes
 						Vector3D p1 = p[0];	// [GEC]
 						Vector3D p2 = p[k];
 						Vector3D p3 = p[k + 1];
-						int c1 = WallPolygon.GetColorForZ(p1.z, p).ToInt();
-						int c2 = WallPolygon.GetColorForZ(p2.z, p).ToInt();
-						int c3 = WallPolygon.GetColorForZ(p3.z, p).ToInt();
+						int c1 = p.GetColorForZ(p1.z).ToInt();
+						int c2 = p.GetColorForZ(p2.z).ToInt();
+						int c3 = p.GetColorForZ(p3.z).ToInt();
 
 						verts.Add(new WorldVertex(p1, c1, texc[0]));
 						verts.Add(new WorldVertex(p2, c2, texc[k]));

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualThing.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualThing.cs
@@ -313,8 +313,16 @@ namespace CodeImp.DoomBuilder.BuilderModes
                         // [ZZ] if sector is using Doom64 lighting, apply thing color here.
                         sectorcolor = PixelColor.Modulate(sd.ColorSprites, areacolor).WithAlpha(alpha).ToInt();
 
-                        Lights col = new Lights();//[GEC]
-                        sectorcolor = PixelColor.Modulate(PixelColor.FromInt(sectorcolor), col.GetLights(level.sector.IdxColor)).WithAlpha(alpha).ToInt();
+						// [GEC] Dual colored lighting calculations
+						Sector sector = level.sector;
+						int idxColorCeil = (sector.IdxColorCeil != 0) ? sector.IdxColorCeil : sector.IdxColor;
+
+						{
+							PixelColor floorCol = Lights.GetColor(sector.IdxColor);
+							PixelColor ceilCol = Lights.GetColor(idxColorCeil);
+							PixelColor psxSectorCol = WallPolygon.GetColorForZ(Thing.Position.z, floorCol, ceilCol, sector.FloorHeight, sector.CeilHeight);
+							sectorcolor = PixelColor.Modulate(PixelColor.FromInt(sectorcolor), psxSectorCol).WithAlpha(alpha).ToInt();
+						}
 
                         //mxd. Calculate fogfactor
                         fogfactor = VisualGeometry.CalculateFogFactor(level.sector, brightness);

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualThing.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualThing.cs
@@ -315,12 +315,11 @@ namespace CodeImp.DoomBuilder.BuilderModes
 
 						// [GEC] Dual colored lighting calculations
 						Sector sector = level.sector;
-						int idxColorCeil = (sector.IdxColorCeil != 0) ? sector.IdxColorCeil : sector.IdxColor;
-
+						
 						{
-							PixelColor floorCol = Lights.GetColor(sector.IdxColor);
-							PixelColor ceilCol = Lights.GetColor(idxColorCeil);
-							PixelColor psxSectorCol = WallPolygon.GetColorForZ(Thing.Position.z, floorCol, ceilCol, sector.FloorHeight, sector.CeilHeight);
+							Lights.ShadingParams shadeParams;
+							Lights.ComputeShadingParams(sector, PixelColor.FromInt(sectorcolor), out shadeParams);
+							PixelColor psxSectorCol = Lights.GetColorForZ(Thing.Position.z, shadeParams);
 							sectorcolor = PixelColor.Modulate(PixelColor.FromInt(sectorcolor), psxSectorCol).WithAlpha(alpha).ToInt();
 						}
 

--- a/Source/Plugins/BuilderModes/VisualModes/VisualCeiling.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualCeiling.cs
@@ -153,8 +153,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
             // [ZZ] Apply Doom 64 lighting here (for extrafloor)
             if (extrafloor != null) color = PixelColor.Modulate(PixelColor.FromInt(color), extrafloor.ColorCeiling).WithAlpha(alpha).ToInt();
 
-            Lights col = new Lights();//[GEC]
-            color = PixelColor.Modulate(PixelColor.FromInt(color), col.GetLights(s.IdxColor)).WithAlpha(alpha).ToInt();
+			int sectorColorIdx = (s.IdxColorCeil != 0) ? s.IdxColorCeil : s.IdxColor; // [GEC]
+            color = PixelColor.Modulate(PixelColor.FromInt(color), Lights.GetColor(sectorColorIdx)).WithAlpha(alpha).ToInt(); // [GEC]
 
             //mxd. Determine fog density
             fogfactor = CalculateFogFactor(targetbrightness);

--- a/Source/Plugins/BuilderModes/VisualModes/VisualCeiling.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualCeiling.cs
@@ -153,8 +153,13 @@ namespace CodeImp.DoomBuilder.BuilderModes
             // [ZZ] Apply Doom 64 lighting here (for extrafloor)
             if (extrafloor != null) color = PixelColor.Modulate(PixelColor.FromInt(color), extrafloor.ColorCeiling).WithAlpha(alpha).ToInt();
 
-			int sectorColorIdx = (s.IdxColorCeil != 0) ? s.IdxColorCeil : s.IdxColor; // [GEC]
-            color = PixelColor.Modulate(PixelColor.FromInt(color), Lights.GetColor(sectorColorIdx)).WithAlpha(alpha).ToInt(); // [GEC]
+			// [GEC] DC: compute the floor color accounting for dual colored light.
+			// The floor color may be a blend of floor + ceiling color depending on the shading params.
+			{
+				Lights.ShadingParams shadeParams;
+				Lights.ComputeShadingParams(s, PixelColor.FromInt(color), out shadeParams);
+				color = Lights.GetColorForZ(s.CeilHeight, shadeParams).ToInt();
+			}
 
             //mxd. Determine fog density
             fogfactor = CalculateFogFactor(targetbrightness);

--- a/Source/Plugins/BuilderModes/VisualModes/VisualCeiling.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualCeiling.cs
@@ -153,8 +153,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
             // [ZZ] Apply Doom 64 lighting here (for extrafloor)
             if (extrafloor != null) color = PixelColor.Modulate(PixelColor.FromInt(color), extrafloor.ColorCeiling).WithAlpha(alpha).ToInt();
 
-			// [GEC] DC: compute the floor color accounting for dual colored light.
-			// The floor color may be a blend of floor + ceiling color depending on the shading params.
+			// [GEC] DC: compute the ceiling color accounting for dual colored light.
+			// The ceiling color may be a blend of floor + ceiling color depending on the shading params.
 			{
 				Lights.ShadingParams shadeParams;
 				Lights.ComputeShadingParams(s, PixelColor.FromInt(color), out shadeParams);

--- a/Source/Plugins/BuilderModes/VisualModes/VisualFloor.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualFloor.cs
@@ -139,7 +139,13 @@ namespace CodeImp.DoomBuilder.BuilderModes
             // [ZZ] Apply Doom 64 lighting here (for extrafloor)
             if (extrafloor != null) color = PixelColor.Modulate(PixelColor.FromInt(color), extrafloor.ColorFloor).WithAlpha(alpha).ToInt();
 
-            color = PixelColor.Modulate(PixelColor.FromInt(color), Lights.GetColor(s.IdxColor)).WithAlpha(alpha).ToInt(); // [GEC]
+			// [GEC] DC: compute the floor color accounting for dual colored light.
+			// The floor color may be a blend of floor + ceiling color depending on the shading params.
+			{
+				Lights.ShadingParams shadeParams;
+				Lights.ComputeShadingParams(s, PixelColor.FromInt(color), out shadeParams);
+				color = Lights.GetColorForZ(s.FloorHeight, shadeParams).ToInt();
+			}
 
             //mxd. Determine fog density
             fogfactor = CalculateFogFactor(targetbrightness);

--- a/Source/Plugins/BuilderModes/VisualModes/VisualFloor.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualFloor.cs
@@ -139,8 +139,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
             // [ZZ] Apply Doom 64 lighting here (for extrafloor)
             if (extrafloor != null) color = PixelColor.Modulate(PixelColor.FromInt(color), extrafloor.ColorFloor).WithAlpha(alpha).ToInt();
 
-            Lights col = new Lights();//[GEC]
-            color = PixelColor.Modulate(PixelColor.FromInt(color), col.GetLights(s.IdxColor)).WithAlpha(alpha).ToInt();
+            color = PixelColor.Modulate(PixelColor.FromInt(color), Lights.GetColor(s.IdxColor)).WithAlpha(alpha).ToInt(); // [GEC]
 
             //mxd. Determine fog density
             fogfactor = CalculateFogFactor(targetbrightness);

--- a/Source/Plugins/BuilderModes/VisualModes/VisualFogBoundary.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualFogBoundary.cs
@@ -97,10 +97,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 
 			// Calculate fog density
 			fogfactor = CalculateFogFactor(lightlevel);
-			poly.lowerColor = PixelColor.FromInt(PixelColor.INT_WHITE); // [GEC]
-			poly.upperColor = poly.lowerColor; // [GEC]
-			poly.lowerColorZ = Sidedef.Sector.FloorHeight; // [GEC]
-			poly.upperColorZ = Sidedef.Sector.CeilHeight; // [GEC]
+			poly.SetShadingParams(Sidedef.Sector, PixelColor.FromInt(PixelColor.INT_WHITE)); // [GEC]
 
 			// Cut off the part below the other floor and above the other ceiling
 			CropPoly(ref poly, osd.Ceiling.plane, true);

--- a/Source/Plugins/BuilderModes/VisualModes/VisualFogBoundary.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualFogBoundary.cs
@@ -97,7 +97,10 @@ namespace CodeImp.DoomBuilder.BuilderModes
 
 			// Calculate fog density
 			fogfactor = CalculateFogFactor(lightlevel);
-			poly.color = PixelColor.INT_WHITE;
+			poly.lowerColor = PixelColor.FromInt(PixelColor.INT_WHITE); // [GEC]
+			poly.upperColor = poly.lowerColor; // [GEC]
+			poly.lowerColorZ = Sidedef.Sector.FloorHeight; // [GEC]
+			poly.upperColorZ = Sidedef.Sector.CeilHeight; // [GEC]
 
 			// Cut off the part below the other floor and above the other ceiling
 			CropPoly(ref poly, osd.Ceiling.plane, true);

--- a/Source/Plugins/BuilderModes/VisualModes/VisualLower.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualLower.cs
@@ -332,10 +332,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
                 base.lightmode = 1;
             }
 
-            poly.color = wallcolor.WithAlpha(255).ToInt();
-
-            Lights col = new Lights();//[GEC]
-            poly.color = PixelColor.Modulate(PixelColor.FromInt(poly.color), col.GetLights(Sidedef.Sector.IdxColor)).WithAlpha(255).ToInt();
+			poly.SetupDualColoredLighting(Sidedef.Sector, wallcolor.WithAlpha(255)); // [GEC]
 
             // Cut off the part above the other floor
             CropPoly(ref poly, osd.Floor.plane, false);

--- a/Source/Plugins/BuilderModes/VisualModes/VisualLower.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualLower.cs
@@ -332,7 +332,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
                 base.lightmode = 1;
             }
 
-			poly.SetupDualColoredLighting(Sidedef.Sector, wallcolor.WithAlpha(255)); // [GEC]
+			poly.SetShadingParams(Sidedef.Sector, wallcolor.WithAlpha(255)); // [GEC]
 
             // Cut off the part above the other floor
             CropPoly(ref poly, osd.Floor.plane, false);

--- a/Source/Plugins/BuilderModes/VisualModes/VisualMiddle3D.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualMiddle3D.cs
@@ -227,7 +227,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 				PixelColor wallcolor = PixelColor.Modulate(sd.Ceiling.colorbelow, wallbrightness);
 				fogfactor = CalculateFogFactor(lightlevel);
 
-				poly.SetupDualColoredLighting(Sidedef.Sector, wallcolor.WithAlpha(255)); // [GEC]
+				poly.SetShadingParams(Sidedef.Sector, wallcolor.WithAlpha(255)); // [GEC]
 
                 // Cut off the part above the 3D floor and below the 3D ceiling
                 CropPoly(ref poly, extrafloor.Floor.plane, false);

--- a/Source/Plugins/BuilderModes/VisualModes/VisualMiddle3D.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualMiddle3D.cs
@@ -226,10 +226,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
 				PixelColor wallbrightness = PixelColor.FromInt(mode.CalculateBrightness(lightlevel, Sidedef));
 				PixelColor wallcolor = PixelColor.Modulate(sd.Ceiling.colorbelow, wallbrightness);
 				fogfactor = CalculateFogFactor(lightlevel);
-				poly.color = wallcolor.WithAlpha(255).ToInt();
 
-                Lights col = new Lights();//[GEC]
-                poly.color = PixelColor.Modulate(PixelColor.FromInt(poly.color), col.GetLights(Sidedef.Sector.IdxColor)).WithAlpha(255).ToInt();
+				poly.SetupDualColoredLighting(Sidedef.Sector, wallcolor.WithAlpha(255)); // [GEC]
 
                 // Cut off the part above the 3D floor and below the 3D ceiling
                 CropPoly(ref poly, extrafloor.Floor.plane, false);

--- a/Source/Plugins/BuilderModes/VisualModes/VisualMiddleBack.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualMiddleBack.cs
@@ -192,8 +192,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 				int wallcolor = PixelColor.Modulate(levelcolor, wallbrightness).WithAlpha((byte)extrafloor.Alpha).ToInt();
 				fogfactor = CalculateFogFactor(lightlevel);
 
-                Lights col = new Lights();//[GEC]
-                poly.color = PixelColor.Modulate(PixelColor.FromInt(poly.color), col.GetLights(Sidedef.Sector.IdxColor)).WithAlpha(255).ToInt();
+				poly.SetupDualColoredLighting(Sidedef.Sector, PixelColor.FromInt(wallcolor)); // [GEC]
 
                 // Cut off the part above the 3D floor and below the 3D ceiling
                 CropPoly(ref poly, bottom, false);

--- a/Source/Plugins/BuilderModes/VisualModes/VisualMiddleBack.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualMiddleBack.cs
@@ -192,7 +192,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 				int wallcolor = PixelColor.Modulate(levelcolor, wallbrightness).WithAlpha((byte)extrafloor.Alpha).ToInt();
 				fogfactor = CalculateFogFactor(lightlevel);
 
-				poly.SetupDualColoredLighting(Sidedef.Sector, PixelColor.FromInt(wallcolor)); // [GEC]
+				poly.SetShadingParams(Sidedef.Sector, PixelColor.FromInt(wallcolor)); // [GEC]
 
                 // Cut off the part above the 3D floor and below the 3D ceiling
                 CropPoly(ref poly, bottom, false);

--- a/Source/Plugins/BuilderModes/VisualModes/VisualMiddleDouble.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualMiddleDouble.cs
@@ -385,7 +385,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
                 base.lightmode = 1;
             }
 
-            poly.SetupDualColoredLighting(Sidedef.Sector, wallcolor.WithAlpha(255)); // [GEC]
+            poly.SetShadingParams(Sidedef.Sector, wallcolor.WithAlpha(255)); // [GEC]
 
             // Cut off the part below the other floor and above the other ceiling
             if (General.Map.PSXDOOM)

--- a/Source/Plugins/BuilderModes/VisualModes/VisualMiddleDouble.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualMiddleDouble.cs
@@ -385,10 +385,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
                 base.lightmode = 1;
             }
 
-            poly.color = wallcolor.WithAlpha(255).ToInt();
-
-            Lights col = new Lights();//[GEC]
-            poly.color = PixelColor.Modulate(PixelColor.FromInt(poly.color), col.GetLights(Sidedef.Sector.IdxColor)).WithAlpha(255).ToInt();
+            poly.SetupDualColoredLighting(Sidedef.Sector, wallcolor.WithAlpha(255)); // [GEC]
 
             // Cut off the part below the other floor and above the other ceiling
             if (General.Map.PSXDOOM)

--- a/Source/Plugins/BuilderModes/VisualModes/VisualMiddleSingle.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualMiddleSingle.cs
@@ -275,10 +275,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
                     base.lightmode = 1;
                 }
 
-                poly.color = wallcolor.WithAlpha(255).ToInt();
-
-                Lights col = new Lights();//[GEC]
-                poly.color = PixelColor.Modulate(PixelColor.FromInt(poly.color), col.GetLights(Sidedef.Sector.IdxColor)).WithAlpha(255).ToInt();
+				poly.SetupDualColoredLighting(Sidedef.Sector, wallcolor.WithAlpha(255)); // [GEC]
 
                 // Cut out pieces that overlap 3D floors in this sector
                 List<WallPolygon> polygons = new List<WallPolygon> { poly };

--- a/Source/Plugins/BuilderModes/VisualModes/VisualMiddleSingle.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualMiddleSingle.cs
@@ -275,7 +275,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
                     base.lightmode = 1;
                 }
 
-				poly.SetupDualColoredLighting(Sidedef.Sector, wallcolor.WithAlpha(255)); // [GEC]
+				poly.SetShadingParams(Sidedef.Sector, wallcolor.WithAlpha(255)); // [GEC]
 
                 // Cut out pieces that overlap 3D floors in this sector
                 List<WallPolygon> polygons = new List<WallPolygon> { poly };

--- a/Source/Plugins/BuilderModes/VisualModes/VisualUpper.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualUpper.cs
@@ -312,7 +312,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
                 base.lightmode = 1;
             }
 
-			poly.SetupDualColoredLighting(Sidedef.Sector, wallcolor.WithAlpha(255)); // [GEC]
+			poly.SetShadingParams(Sidedef.Sector, wallcolor.WithAlpha(255)); // [GEC]
 
             // Cut off the part below the other ceiling
             CropPoly(ref poly, osd.Ceiling.plane, false);

--- a/Source/Plugins/BuilderModes/VisualModes/VisualUpper.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualUpper.cs
@@ -305,15 +305,14 @@ namespace CodeImp.DoomBuilder.BuilderModes
             PixelColor wallbrightness = PixelColor.FromInt(mode.CalculateBrightness(lightlevel, Sidedef));
 			PixelColor wallcolor = PixelColor.Modulate(sd.Ceiling.colorbelow, wallbrightness);
 			fogfactor = CalculateFogFactor(lightlevel);
+
             if (General.Map.PSXDOOM)//[GEC]
             {
                 fogfactor = CalculateFogFactor(255);
                 base.lightmode = 1;
             }
-            poly.color = wallcolor.WithAlpha(255).ToInt();
 
-            Lights col = new Lights();//[GEC]
-            poly.color = PixelColor.Modulate(PixelColor.FromInt(poly.color), col.GetLights(Sidedef.Sector.IdxColor)).WithAlpha(255).ToInt();
+			poly.SetupDualColoredLighting(Sidedef.Sector, wallcolor.WithAlpha(255)); // [GEC]
 
             // Cut off the part below the other ceiling
             CropPoly(ref poly, osd.Ceiling.plane, false);

--- a/Source/Plugins/BuilderModes/VisualModes/WallPolygon.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/WallPolygon.cs
@@ -11,12 +11,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 {
 	internal class WallPolygon : List<Vector3D>
 	{
-		// [GEC] DC: the lower and upper colors for the wall polygon and the z values at which does colors are applied.
-		// These values are used to compute the color for a vertex depending on it's height with two colored lighting.
-		public PixelColor lowerColor;
-		public PixelColor upperColor;
-		public float lowerColorZ;
-		public float upperColorZ;
+		public Lights.ShadingParams shadeParams; // [GEC]
 		
 		// Constructors
 		public WallPolygon() { }
@@ -25,53 +20,19 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		// This copies all the wall properties
 		public void CopyProperties(WallPolygon target)
 		{
-			target.lowerColor = this.lowerColor; // [GEC]
-			target.upperColor = this.upperColor;
-			target.lowerColorZ = this.lowerColorZ;
-			target.upperColorZ = this.upperColorZ;
+			target.shadeParams = this.shadeParams; // [GEC]
 		}
 
-		// [GEC] DC: figure out the lower and upper wall colors and the Z values at which they apply.
-		// Use an input sector and base color to decide.
-		public void SetupDualColoredLighting(Sector sector, PixelColor baseColor)
+		 // [GEC]
+		public void SetShadingParams(Sector sector, PixelColor baseColor)
 		{
-			lowerColorZ = sector.FloorHeight;
-			upperColorZ = sector.CeilHeight;
-
-			// Note: if the upper color is undefined, use the lower color as the upper color
-			int upperColorIdx = (sector.IdxColorCeil != 0) ? sector.IdxColorCeil : sector.IdxColor;
-			lowerColor = PixelColor.Modulate(baseColor, Lights.GetColor(sector.IdxColor)).WithAlpha(255);
-			upperColor = PixelColor.Modulate(baseColor, Lights.GetColor(upperColorIdx)).WithAlpha(255);
+			Lights.ComputeShadingParams(sector, baseColor, out shadeParams);
 		}
 
-		// [GEC] DC: dual color calculation.
-		// Gets the color to use for the given Z (height) value given the specified dual color lighting params.
-		public static PixelColor GetColorForZ(
-			float z,
-			PixelColor lowerColor,
-			PixelColor upperColor,
-			float lowerColorZ,
-			float upperColorZ
-		)
+		// [GEC]
+		public PixelColor GetColorForZ(float z)
 		{
-			// Same color? If so then don't do any interpolation:
-			if (lowerColor.Equals(upperColor))
-				return lowerColor;
-
-			// If there is zero or invalid sized z range then just return the floor color
-			float zRange = upperColorZ - lowerColorZ;
-
-			if (zRange <= 0.0f)
-				return lowerColor;
-
-			// Interpolate between the two colors based on z
-			float t = (z - lowerColorZ) / zRange;
-			return PixelColor.Lerp(lowerColor, upperColor, t);
+			return Lights.GetColorForZ(z, shadeParams);
 		}
-
-		public static PixelColor GetColorForZ(float z, WallPolygon poly)
-        {
-			return GetColorForZ(z, poly.lowerColor, poly.upperColor, poly.lowerColorZ, poly.upperColorZ);
-        }
 	}
 }

--- a/Source/Plugins/BuilderModes/VisualModes/WallPolygon.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/WallPolygon.cs
@@ -2,6 +2,8 @@
 
 using System.Collections.Generic;
 using CodeImp.DoomBuilder.Geometry;
+using CodeImp.DoomBuilder.Map;
+using CodeImp.DoomBuilder.Rendering;
 
 #endregion
 
@@ -9,8 +11,12 @@ namespace CodeImp.DoomBuilder.BuilderModes
 {
 	internal class WallPolygon : List<Vector3D>
 	{
-		// The color that the wall should have
-		public int color;
+		// [GEC] DC: the lower and upper colors for the wall polygon and the z values at which does colors are applied.
+		// These values are used to compute the color for a vertex depending on it's height with two colored lighting.
+		public PixelColor lowerColor;
+		public PixelColor upperColor;
+		public float lowerColorZ;
+		public float upperColorZ;
 		
 		// Constructors
 		public WallPolygon() { }
@@ -19,7 +25,53 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		// This copies all the wall properties
 		public void CopyProperties(WallPolygon target)
 		{
-			target.color = this.color;
+			target.lowerColor = this.lowerColor; // [GEC]
+			target.upperColor = this.upperColor;
+			target.lowerColorZ = this.lowerColorZ;
+			target.upperColorZ = this.upperColorZ;
 		}
+
+		// [GEC] DC: figure out the lower and upper wall colors and the Z values at which they apply.
+		// Use an input sector and base color to decide.
+		public void SetupDualColoredLighting(Sector sector, PixelColor baseColor)
+		{
+			lowerColorZ = sector.FloorHeight;
+			upperColorZ = sector.CeilHeight;
+
+			// Note: if the upper color is undefined, use the lower color as the upper color
+			int upperColorIdx = (sector.IdxColorCeil != 0) ? sector.IdxColorCeil : sector.IdxColor;
+			lowerColor = PixelColor.Modulate(baseColor, Lights.GetColor(sector.IdxColor)).WithAlpha(255);
+			upperColor = PixelColor.Modulate(baseColor, Lights.GetColor(upperColorIdx)).WithAlpha(255);
+		}
+
+		// [GEC] DC: dual color calculation.
+		// Gets the color to use for the given Z (height) value given the specified dual color lighting params.
+		public static PixelColor GetColorForZ(
+			float z,
+			PixelColor lowerColor,
+			PixelColor upperColor,
+			float lowerColorZ,
+			float upperColorZ
+		)
+		{
+			// Same color? If so then don't do any interpolation:
+			if (lowerColor.Equals(upperColor))
+				return lowerColor;
+
+			// If there is zero or invalid sized z range then just return the floor color
+			float zRange = upperColorZ - lowerColorZ;
+
+			if (zRange <= 0.0f)
+				return lowerColor;
+
+			// Interpolate between the two colors based on z
+			float t = (z - lowerColorZ) / zRange;
+			return PixelColor.Lerp(lowerColor, upperColor, t);
+		}
+
+		public static PixelColor GetColorForZ(float z, WallPolygon poly)
+        {
+			return GetColorForZ(z, poly.lowerColor, poly.upperColor, poly.lowerColorZ, poly.upperColorZ);
+        }
 	}
 }


### PR DESCRIPTION
Hey Erick, this pull request adds the ability for PSX Doom builder to support dual colored lighting. At the moment it is just enabled for the PsyDoom configuration but it can also be easily enabled for the Master Edition by setting `enablepsxdualcolorlighting = true`. The feature makes use of unused bits in the sector flags field to encode the 2nd color as well as few settings that allow the gradient to be controlled somewhat (tweaking the floor or ceiling location for shading purposes).

Here's a side by side comparison of the editor and in-game:
![image](https://user-images.githubusercontent.com/3496135/121849245-f5c31000-cc9f-11eb-9917-008d5968f666.png)

Let me know if there are any tweaks you'd like made to the pull request, or feel free to make edits yourself. Thanks!