### PR TITLE
Added PsyDoom specific "datadir" parameter

### DIFF
--- a/Build/Configurations/Includes/PSXDoom_common.cfg
+++ b/Build/Configurations/Includes/PSXDoom_common.cfg
@@ -4,7 +4,7 @@ common
   include("Common.cfg");
 
   // Default testing parameters
-  include("Test_params.cfg", "vanilla_mapxx");
+  testparameters = "-datadir \"%DD\" -skill \"%S\" -warp %L1%L2 %NM";
   testshortpaths = true;
 
   // Default nodebuilder configurations

--- a/Help/w_gameconfigurations.html
+++ b/Help/w_gameconfigurations.html
@@ -38,7 +38,11 @@
 		The following special placeholders can be used in the parameters;
 		<table border="0" cellspacing="6" width="90%">
 		<tr>
-			<td width="50" valign="top"><b>%F</b></td>
+			<td width="50" valign="top"><b>%DD</b></td>
+			<td>The data directory which contains all of the files to use for this mod. This is unique to PsyDoom and should be used.</td>
+		</tr>
+		<tr>
+			<td valign="top"><b>%F</b></td>
 			<td>WAD file with the map that is to be tested. NOTE: this is a temporary file and not the file you opened or saved.</td>
 		</tr>
 		<tr>

--- a/Source/Core/General/Launcher.cs
+++ b/Source/Core/General/Launcher.cs
@@ -120,11 +120,19 @@ namespace CodeImp.DoomBuilder
 			string p_ap = "", p_apq = "";
 			string p_l1 = "", p_l2 = "";
 			string p_nm = "";
+			string p_dd = "";
 			string f = tempwad;
 			
 			// Make short path if needed
 			if(shortpaths) f = General.GetShortFilePath(f);
 			
+			// Get data directory
+			p_dd = Path.GetDirectoryName(General.Map.FilePathName);
+			if(shortpaths)
+			{
+				p_dd = General.GetShortFilePath(p_dd);
+			}
+
 			// Find the first IWAD file
 			if(General.Map.Data.FindFirstIWAD(out iwadloc))
 			{
@@ -214,6 +222,9 @@ namespace CodeImp.DoomBuilder
 			if(!General.Settings.TestMonsters) p_nm = "-nomonsters";
 			
 			// Make sure all our placeholders are in uppercase
+			outp = outp.Replace("%dd", "%DD");
+			outp = outp.Replace("%Dd", "%DD");
+			outp = outp.Replace("%dD", "%DD");
 			outp = outp.Replace("%f", "%F");
 			outp = outp.Replace("%wp", "%WP");
 			outp = outp.Replace("%wf", "%WF");
@@ -233,6 +244,7 @@ namespace CodeImp.DoomBuilder
 			outp = outp.Replace("%nm", "%NM");
 			
 			// Replace placeholders with actual values
+			outp = outp.Replace("%DD", p_dd);
 			outp = outp.Replace("%F", f);
 			outp = outp.Replace("%WP", p_wp);
 			outp = outp.Replace("%WF", p_wf);

--- a/Source/Core/Windows/ConfigForm.resx
+++ b/Source/Core/Windows/ConfigForm.resx
@@ -178,7 +178,8 @@
     <value>416, 17</value>
   </metadata>
   <data name="labelparameters.ToolTip" xml:space="preserve">
-    <value>%F     - WAD file with the map that is to be tested. NOTE: this is a temporary file and not the file you opened or saved. 
+    <value>%DD  - The data directory which contains all of the files to use for this mod. This is unique to PsyDoom and should be used.
+%F     - WAD file with the map that is to be tested. NOTE: this is a temporary file and not the file you opened or saved. 
 %WP - IWAD resource file with full path included. This is the first (highest) IWAD file that is found in the resources list. 
 %WF - IWAD resource filename only, without path. This is the first (highest) IWAD file that is found in the resources list. 
 %L     - Map lump name as is set in the map options window.


### PR DESCRIPTION
This update will allow seamless testing with PsyDoom using the F9 key in Doom Builder PSX.