### PR TITLE
Fix dual colored lighting in the editor sometimes over-saturating colors

### DIFF
--- a/Source/Core/Map/Lights.cs
+++ b/Source/Core/Map/Lights.cs
@@ -195,6 +195,7 @@ namespace CodeImp.DoomBuilder.Map
 
             // Interpolate between the two colors based on z
             float t = (z - shadeParams.lowerColorZ) / zRange;
+            t = Math.Min(Math.Max(t, 0.0f), 1.0f);
             return PixelColor.Lerp(shadeParams.lowerColor, shadeParams.upperColor, t);
         }
     }


### PR DESCRIPTION
Fix dual colored lighting in the editor sometimes over-saturating colors and not matching the in-engine display in PsyDoom or GEC ME.

When deciding the color at a particular z height within a sector, we must ensure that the lerp factor between the floor and ceiling color is restricted to a 0-1 range. Failure to do so may result in sector colors being altered incorrectly.